### PR TITLE
add background job to auto-reject past pending.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,9 @@ gem 'pg', '~> 1.1'
 gem 'puma', '~> 5.0'
 gem 'rails', '~> 7.0.4', '>= 7.0.4.2'
 gem 'redis', '~> 4.0'
+gem 'rufus-scheduler'
 gem 'sassc-rails'
+gem 'sidekiq'
 gem 'sprockets-rails'
 gem 'stimulus-rails'
 gem 'turbo-rails'
@@ -40,6 +42,7 @@ end
 group :test do
   gem 'capybara'
   gem 'faker' # Fake data
+  gem 'rspec-sidekiq'
   gem 'selenium-webdriver'
   gem 'webdrivers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
       xpath (~> 3.2)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.0)
     crass (1.0.6)
     date (3.3.3)
     debug (1.7.1)
@@ -107,6 +108,8 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
     erubi (1.12.0)
+    et-orbi (1.2.7)
+      tzinfo
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -115,6 +118,9 @@ GEM
     faker (3.2.0)
       i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
+    fugit (1.8.1)
+      et-orbi (~> 1, >= 1.2.7)
+      raabro (~> 1.4)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -178,6 +184,7 @@ GEM
     public_suffix (5.0.1)
     puma (5.6.5)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.6.2)
     rack (2.2.7)
     rack-test (2.0.2)
@@ -211,6 +218,8 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     redis (4.8.1)
+    redis-client (0.14.1)
+      connection_pool
     regexp_parser (2.7.0)
     reline (0.3.2)
       io-console (~> 0.5)
@@ -234,6 +243,9 @@ GEM
       rspec-expectations (~> 3.11)
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
+    rspec-sidekiq (3.1.0)
+      rspec-core (~> 3.0, >= 3.0.0)
+      sidekiq (>= 2.4.0)
     rspec-support (3.12.0)
     rubocop (1.50.2)
       json (~> 2.3)
@@ -263,6 +275,8 @@ GEM
     ruby-vips (2.1.4)
       ffi (~> 1.12)
     rubyzip (2.3.2)
+    rufus-scheduler (3.8.2)
+      fugit (~> 1.1, >= 1.1.6)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -275,6 +289,11 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sidekiq (7.0.9)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.11.0)
     sprockets (4.2.0)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -337,12 +356,15 @@ DEPENDENCIES
   rails (~> 7.0.4, >= 7.0.4.2)
   redis (~> 4.0)
   rspec-rails
+  rspec-sidekiq
   rubocop
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  rufus-scheduler
   sassc-rails
   selenium-webdriver
+  sidekiq
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,3 @@
-class ApplicationJob < ActiveJob::Base
-  # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
-
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
+class ApplicationJob
+  include Sidekiq::Worker
 end

--- a/app/jobs/pair_request/auto_expire_job.rb
+++ b/app/jobs/pair_request/auto_expire_job.rb
@@ -1,0 +1,12 @@
+class PairRequest
+  class AutoExpireJob < ApplicationJob
+    sidekiq_options queue: 'low'
+
+    # rubocop:disable Rails/SkipsModelValidations
+    def perform
+      PairRequest.pending.where('pair_requests.when < ?',
+        Time.current).update_all(status: :expired)
+    end
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end

--- a/app/models/pair_request.rb
+++ b/app/models/pair_request.rb
@@ -27,8 +27,8 @@ class PairRequest < ApplicationRecord
 
   validates :when,
     presence: true,
-    inclusion: { in: (Date.today..(Date.today + 1.month)) }
-  validates :duration, presence: true, numericality: { greater_than_or_equal_to: 15.minutes }
+    inclusion: { in: (Date.current..(Date.current + 1.month)) }
+  validates :duration, presence: true, numericality: { greater_than_or_equal_to: 5.minutes }
   validates :status, presence: true
 
   enum status: {

--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -1,0 +1,14 @@
+# NOTE: this is a temporary solution.
+# The issue with this is when we run multiple containers there is no real "locking" mechanism
+# across them. So we might end up with multiple containers running the same job.
+# This is fine for now because these jobs will be idempotent.
+# But this is something we should fix in the future.
+#
+
+require 'rufus-scheduler'
+
+s = Rufus::Scheduler.singleton
+
+s.every '30m' do
+  PairRequest::AutoExpireJob.perform_async
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,11 @@
+require 'sidekiq/web'
+require 'admin_constraint'
+
 Rails.application.routes.draw do
+  constraints(AdminConstraint) do
+    mount Sidekiq::Web => '/sidekiq'
+  end
+
   devise_for :users, skip: [:registrations]
   as :user do
     get 'users/edit' => 'devise/registrations#edit', as: 'edit_user_registration'
@@ -9,6 +16,7 @@ Rails.application.routes.draw do
   root to: 'landing#index'
   # Shortcuts
   get 'landing/index'
+
   # Alphabetized Routes
   # resources :pair_requests do
   #   resources :acceptances, only: [:create, :destroy]

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,10 @@
+:concurrency: 5
+staging:
+  :concurrency: 10
+production:
+  :concurrency: 10
+:queues:
+  - critical
+  - default
+  - low
+  - backfills

--- a/lib/admin_constraint.rb
+++ b/lib/admin_constraint.rb
@@ -1,0 +1,10 @@
+class AdminConstraint
+  def self.matches?(request)
+    return false if request.session['warden.user.user.key'].blank?
+
+    user_id, _key = request.session['warden.user.user.key']
+
+    user = User.find(user_id)
+    user.admin?
+  end
+end

--- a/spec/factories/pair_requests.rb
+++ b/spec/factories/pair_requests.rb
@@ -26,6 +26,7 @@ FactoryBot.define do
     association :author, factory: :user
     association :invitee, factory: :user
     duration { 15.minutes }
-    add_attribute(:when) { DateTime.now }
+
+    add_attribute(:when) { 1.day.from_now }
   end
 end

--- a/spec/factories/traits.rb
+++ b/spec/factories/traits.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  trait :skip_validation do
+    to_create { |instance| instance.save(validate: false) }
+  end
+end

--- a/spec/jobs/pair_request/auto_expire_job_spec.rb
+++ b/spec/jobs/pair_request/auto_expire_job_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe PairRequest::AutoExpireJob, type: :job do
+  let!(:expired_pair_request) do
+    create(:pair_request, :skip_validation, status: :pending, when: 1.day.ago)
+  end
+  let!(:pending_pair_request) { create(:pair_request) }
+  let!(:accepted_pair_request) { create(:pair_request, status: :accepted) }
+
+  describe '#perform' do
+    it 'expires pair requests that are expired' do
+      described_class.new.perform
+
+      expect(expired_pair_request.reload.status).to eq('expired')
+      expect(pending_pair_request.reload.status).to eq('pending')
+      expect(accepted_pair_request.reload.status).to eq('accepted')
+    end
+  end
+end

--- a/spec/models/pair_request_spec.rb
+++ b/spec/models/pair_request_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe PairRequest do
       expect(subject).to be_valid
     end
 
-    context 'when duration is less than 15 minutes' do
-      let(:duration) { 10.minutes }
+    context 'when duration is less than 5 minutes' do
+      let(:duration) { 4.minutes }
 
       it 'is invalid' do
         expect(subject).not_to be_valid


### PR DESCRIPTION
## Description
This adds a background job to auto-reject any pair requests that are still pending (past the when date).
Also introduces a simple scheduler to help run these jobs, and all the sidekiq configuration.

## Deployment
Before merging this in, I need to setup heroku with redis so that sidekiq works (separate instance from cache).