### PR TITLE
Build Devise invitable UI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,9 @@ gem 'devise_invitable'
 gem 'image_processing', '~> 1.2'
 gem 'importmap-rails'
 gem 'jbuilder'
+gem 'paper_trail'
 gem 'pg', '~> 1.1'
 gem 'puma', '~> 5.0'
-gem 'paper_trail'
 gem 'rails', '~> 7.0.4', '>= 7.0.4.2'
 gem 'redis', '~> 4.0'
 gem 'rufus-scheduler'
@@ -39,6 +39,7 @@ end
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'letter_opener'
   gem 'web-console'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,10 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.3)
+    launchy (2.5.2)
+      addressable (~> 2.8)
+    letter_opener (1.8.1)
+      launchy (>= 2.2, < 3)
     loofah (2.21.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -372,6 +376,7 @@ DEPENDENCIES
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
+  letter_opener
   paper_trail
   pg (~> 1.1)
   pry-byebug

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,0 +1,3 @@
+class InvitationsController < Devise::InvitationsController
+  before_action -> { authorize :invitation }
+end

--- a/app/policies/invitation_policy.rb
+++ b/app/policies/invitation_policy.rb
@@ -1,0 +1,13 @@
+class InvitationPolicy < ApplicationPolicy
+  def new?
+    user.admin?
+  end
+
+  def create?
+    user.admin?
+  end
+
+  def update?
+    true
+  end
+end

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,0 +1,22 @@
+<h2><%= t "devise.invitations.edit.header" %></h2>
+
+<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= f.hidden_field :invitation_token, readonly: true %>
+
+  <% if f.object.class.require_password_on_accepting %>
+    <div class="field">
+      <%= f.label :password %><br />
+      <%= f.password_field :password %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password_confirmation %><br />
+      <%= f.password_field :password_confirmation %>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= f.submit t("devise.invitations.edit.submit_button") %>
+  </div>
+<% end %>

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,22 +1,21 @@
-<h2><%= t "devise.invitations.edit.header" %></h2>
-
-<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
+<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put, class: 'container max-w-md mx-auto' }) do |f| %>
+  <h2 class='text-3xl mb-4'><%= t "devise.invitations.edit.header" %></h2>
   <%= render "devise/shared/error_messages", resource: resource %>
   <%= f.hidden_field :invitation_token, readonly: true %>
 
   <% if f.object.class.require_password_on_accepting %>
-    <div class="field">
-      <%= f.label :password %><br />
-      <%= f.password_field :password %>
+    <div class="form-control">
+      <%= f.label :password, class: 'label label-text text-lg' %>
+      <%= f.password_field :password, class: 'input input-bordered' %>
     </div>
 
-    <div class="field">
-      <%= f.label :password_confirmation %><br />
-      <%= f.password_field :password_confirmation %>
+    <div class="form-control mb-8">
+      <%= f.label :password_confirmation, class: 'label label-text text-lg' %>
+      <%= f.password_field :password_confirmation, class: 'input input-bordered' %>
     </div>
   <% end %>
 
-  <div class="actions">
-    <%= f.submit t("devise.invitations.edit.submit_button") %>
+  <div class="form-control">
+    <%= f.submit t("devise.invitations.edit.submit_button"), class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,0 +1,16 @@
+<h2><%= t "devise.invitations.new.header" %></h2>
+
+<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <% resource.class.invite_key_fields.each do |field| -%>
+    <div class="field">
+      <%= f.label field %><br />
+      <%= f.text_field field %>
+    </div>
+  <% end -%>
+
+  <div class="actions">
+    <%= f.submit t("devise.invitations.new.submit_button") %>
+  </div>
+<% end %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,16 +1,16 @@
-<h2><%= t "devise.invitations.new.header" %></h2>
 
-<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post, class: 'container max-w-md mx-auto' }) do |f| %>
+  <h2 class='text-3xl mb-4'><%= t "devise.invitations.new.header" %></h2>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <% resource.class.invite_key_fields.each do |field| -%>
-    <div class="field">
-      <%= f.label field %><br />
-      <%= f.text_field field %>
+    <div class="form-control">
+      <%= f.label field, class: 'label label-text text-lg' %>
+      <%= f.text_field field, class: 'input input-bordered' %>
     </div>
   <% end -%>
 
-  <div class="actions">
-    <%= f.submit t("devise.invitations.new.submit_button") %>
+  <div class="form-control mt-8">
+    <%= f.submit t("devise.invitations.new.submit_button"), class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,0 +1,11 @@
+<p><%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %></p>
+
+<p><%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %></p>
+
+<p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, invitation_token: @token) %></p>
+
+<% if @resource.invitation_due_at %>
+  <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>
+<% end %>
+
+<p><%= t("devise.mailer.invitation_instructions.ignore") %></p>

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -1,0 +1,11 @@
+<%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %>
+
+<%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %>
+
+<%= accept_invitation_url(@resource, invitation_token: @token) %>
+
+<% if @resource.invitation_due_at %>
+  <%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %>
+<% end %>
+
+<%= t("devise.mailer.invitation_instructions.ignore") %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -15,6 +15,11 @@
         <li>
           <%= link_to 'Pair Requests', pair_requests_path %>
         </li>
+        <% if policy(:invitation).new? %>
+          <li>
+            <%= link_to 'Send Invite', new_user_invitation_path %>
+          </li>
+        <% end %>
         <li>
           <%= link_to 'Logout', destroy_user_session_path, data: { "turbo-method": :delete }, class: "btn btn-primary btn-outline" %>
         </li>
@@ -41,6 +46,11 @@
           <li>
             <%= link_to 'Pair Requests', pair_requests_path %>
           </li>
+          <% if policy(:invitation).new? %>
+            <li>
+              <%= link_to 'Send Invite', new_user_invitation_path %>
+            </li>
+          <% end %>
           <li class="nav-item">
             <%= link_to 'Logout', destroy_user_session_path, data: { "turbo-method": :delete } %>
           </li>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -17,7 +17,7 @@
         </li>
         <% if policy(:invitation).new? %>
           <li>
-            <%= link_to 'Send Invite', new_user_invitation_path %>
+            <%= link_to 'Invite New User', new_user_invitation_path %>
           </li>
         <% end %>
         <li>
@@ -48,7 +48,7 @@
           </li>
           <% if policy(:invitation).new? %>
             <li>
-              <%= link_to 'Send Invite', new_user_invitation_path %>
+              <%= link_to 'Invite New User', new_user_invitation_path %>
             </li>
           <% end %>
           <li class="nav-item">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,6 +70,8 @@ Rails.application.configure do
 
   # NOTE: integrate with letter_opener.
 
-  config.action_mailer.delivery_method = :smtp
+  # config.action_mailer.delivery_method = :smtp
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => '/sidekiq'
   end
 
-  devise_for :users, skip: [:registrations]
+  devise_for :users, skip: [:registrations], controllers: { invitations: 'invitations' }
   as :user do
     get 'users/edit' => 'devise/registrations#edit', as: 'edit_user_registration'
     put 'users' => 'devise/registrations#update', as: 'user_registration'

--- a/spec/policies/invitation_policy_spec.rb
+++ b/spec/policies/invitation_policy_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe InvitationPolicy do
+  subject { described_class }
+
+  let(:member) { build(:user) }
+  let(:admin) { build(:user, :admin) }
+
+  permissions :new?, :create? do
+    it 'denies access to regular member users' do
+      expect(subject).not_to permit(member)
+    end
+
+    it 'grants access to admin users' do
+      expect(subject).to permit(admin)
+    end
+  end
+
+  permissions :edit?, :update? do
+    it 'grants access to member users' do
+      expect(subject).to permit(member)
+    end
+  end
+end


### PR DESCRIPTION
## This PR
- Generates views/mailers for `devise_invitable`
- Styles new forms in accordance with existing login page styles
- Adds an `InvitationPolicy` and uses it to restrict creating invitations to admin users. This policy is also tested.
- Adds letter opener

I ended up doing a couple of things a bit differently than the design doc. One is that actually using/testing this email system is much easier with letter opener, so I just went ahead and added it in. 

The other is that I was originally going to use the builtin controller filter `devise_invitable` has to lock sending invitations to admins only. But that builtin filter is looking at class names to make its determinations, and our app has all users under one class with the `role` field differentiating members and admins. I'm sure I could customize this, but I also wanted to conditionally display a link in the navbar for sending out invitations. At that point, I figured I'd just make a Pundit policy for it and handle the authorization through that.

Maybe one of things I'd specifically like feedback on is:
```rb
class InvitationsController < Devise::InvitationsController
```
Not sure about my controller name here, but a better name didn't immediately occur to me. `ApplicationInvitationsController` maybe?