### PR TITLE
Adds seed data for user and pair_requet

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,45 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
-# User.create!(email: "test@test.com", password: "password", role: "admin")
+begin
+  puts "Seeding users..."
+
+  user_data = [
+    { email: "admin@user.com", password: "password", role: "admin" },
+    { email: "user1@user.com", password: "password", role: "member" },
+    { email: "user2@user.com", password: "password", role: "member" },
+    { email: "user3@user.com", password: "password", role: "member" }
+  ]
+
+  users = []
+
+  User.transaction do
+    user_data.each do |data|
+      user = User.create!(data)
+      users << user
+      puts "User #{user.email} created"
+    end
+  end
+
+  puts "Users seeded successfully!"
+
+  puts "Seeding pair requests..."
+
+  pair_request_data = [
+    { status: "pending", author: users[1], invitee: users[2], when: 1.day.from_now, duration: 30.minutes },
+    { status: "pending", author: users[1], invitee: users[3], when: 1.day.from_now, duration: 30.minutes },
+    { status: "pending", author: users[2], invitee: users[3], when: 1.day.from_now, duration: 45.minutes },
+    { status: "rejected", author: users[1], invitee: users[2], when: 1.day.from_now, duration: 30.minutes },
+    { status: "accepted", author: users[1], invitee: users[2], when: 5.day.from_now, duration: 60.minutes },
+    { status: "rejected", author: users[3], invitee: users[1], when: 20.days.from_now, duration: 15.minutes },
+  ]
+
+  PairRequest.transaction do
+    pair_request_data.each do |data|
+      PairRequest.create!(data)
+    end
+  end
+
+  puts "Pair requests seeded successfully!"
+  
+rescue StandardError => e
+  puts "Error occurred while seeding: #{e.message}"
+  puts e.backtrace.join("\n")
+end


### PR DESCRIPTION
This Pr fixes issue 54: “Create Seeds for Users and Pair Requests”. 
A couple of things:
1. I am not great at naming variables so I stack to “admin” “user1”, “user2”, etc. let me know if i should change the naming. 
2. I used fixed data to create users since it’ll make it easy to refer to it in the future. 
3. I added a few pair_requets with some scenarios, but I'm not sure I covered all. Let me know if I’m missing something.
