### PR TITLE
hide action column on mobile to improve readability

### DIFF
--- a/app/components/table_cell_component.html.erb
+++ b/app/components/table_cell_component.html.erb
@@ -1,12 +1,12 @@
 <% if container_link.present? %>
   <%= link_to(
     container_link,
-    class: "table-cell text-left p-2 align-middle"
+    class: "#{hidden_on_mobile ? "hidden sm:table-cell" : "table-cell"} text-left p-2 align-middle"
   ) do %>
     <%= content %>
   <% end %>
 <% else %>
-  <div class="table-cell text-left p-2 align-middle">
+  <div class="text-left p-2 align-middle <%= hidden_on_mobile ? "hidden sm:table-cell" : "table-cell" %>">
     <%= content %>
   </div>
 <% end %>

--- a/app/components/table_cell_component.html.erb
+++ b/app/components/table_cell_component.html.erb
@@ -1,12 +1,12 @@
 <% if container_link.present? %>
   <%= link_to(
     container_link,
-    class: "#{hidden_on_mobile ? "hidden sm:table-cell" : "table-cell"} text-left p-2 align-middle"
+    class: "#{classes} text-left p-2 align-middle"
   ) do %>
     <%= content %>
   <% end %>
 <% else %>
-  <div class="text-left p-2 align-middle <%= hidden_on_mobile ? "hidden sm:table-cell" : "table-cell" %>">
+  <div class="text-left p-2 align-middle <%= classes %>">
     <%= content %>
   </div>
 <% end %>

--- a/app/components/table_cell_component.rb
+++ b/app/components/table_cell_component.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class TableCellComponent < ViewComponent::Base
-  def initialize(container_link: nil)
+  def initialize(container_link: nil, hidden_on_mobile: false)
     @container_link = container_link
+    @hidden_on_mobile = hidden_on_mobile
   end
 
   private
 
-  attr_reader :container_link
+  attr_reader :container_link, :hidden_on_mobile
 end

--- a/app/components/table_cell_component.rb
+++ b/app/components/table_cell_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TableCellComponent < ViewComponent::Base
-  def initialize(container_link: nil, classes: nil)
+  def initialize(container_link: nil, classes: 'table-cell')
     @container_link = container_link
     @classes = classes
   end

--- a/app/components/table_cell_component.rb
+++ b/app/components/table_cell_component.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class TableCellComponent < ViewComponent::Base
-  def initialize(container_link: nil, classes: 'table-cell')
+  def initialize(container_link: nil, class_names: 'table-cell')
     @container_link = container_link
-    @classes = classes
+    @class_names = class_names
   end
 
   private
 
-  attr_reader :container_link, :classes
+  attr_reader :container_link, :class_names
 end

--- a/app/components/table_cell_component.rb
+++ b/app/components/table_cell_component.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class TableCellComponent < ViewComponent::Base
-  def initialize(container_link: nil, hidden_on_mobile: false)
+  def initialize(container_link: nil, classes: nil)
     @container_link = container_link
-    @hidden_on_mobile = hidden_on_mobile
+    @classes = classes
   end
 
   private
 
-  attr_reader :container_link, :hidden_on_mobile
+  attr_reader :container_link, :classes
 end

--- a/app/views/pair_requests/index.html.erb
+++ b/app/views/pair_requests/index.html.erb
@@ -16,15 +16,15 @@
       <% @pair_requests.each do |pair_request| %>
         <div class="table-row odd:bg-white even:bg-neutral-100 hover:bg-neutral-200 divide-x-2 divide-black">
 
-          <%= render TableCellComponent.new(container_link: pair_request, classes: 'table-cell') do %>
+          <%= render TableCellComponent.new(container_link: pair_request) do %>
             <p>John</p><p>Doe</p>
           <% end %>
 
-          <%= render TableCellComponent.new(container_link: pair_request, classes: 'table-cell') do %>
+          <%= render TableCellComponent.new(container_link: pair_request) do %>
             <%= format_request_date(pair_request) %>
           <% end %>
 
-          <%= render TableCellComponent.new(container_link: pair_request, classes: 'table-cell') do %>
+          <%= render TableCellComponent.new(container_link: pair_request) do %>
             <%= pair_request.status.capitalize %>
           <% end %>
 

--- a/app/views/pair_requests/index.html.erb
+++ b/app/views/pair_requests/index.html.erb
@@ -3,32 +3,32 @@
 <h1 class="text-2xl font-bold mb-4 text-center">My Requests</h1>
 
 <div class="p-2">
-  <div class="table w-full border-2 border-black text-xs sm:text-sm md:text-base">
+  <div class="table w-full border-2 border-black text-md md:text-base">
     <div class="table-header-group">
       <div class="table-row font-bold bg-neutral-400 divide-x-2 divide-black">
         <div class="table-cell text-left p-1">Partner</div>
         <div class="table-cell text-left p-1">When</div>
         <div class="table-cell text-left p-1">Status</div>
-        <div class="text-left p-1 hidden md:table-cell">Actions</div>
+        <div class="text-left p-1 hidden sm:table-cell">Actions</div>
       </div>
     </div>
     <div class="table-row-group">
       <% @pair_requests.each do |pair_request| %>
         <div class="table-row odd:bg-white even:bg-neutral-100 hover:bg-neutral-200 divide-x-2 divide-black">
 
-          <%= render TableCellComponent.new(container_link: pair_request) do %>
+          <%= render TableCellComponent.new(container_link: pair_request, classes: 'table-cell') do %>
             <p>John</p><p>Doe</p>
           <% end %>
 
-          <%= render TableCellComponent.new(container_link: pair_request) do %>
+          <%= render TableCellComponent.new(container_link: pair_request, classes: 'table-cell') do %>
             <%= format_request_date(pair_request) %>
           <% end %>
 
-          <%= render TableCellComponent.new(container_link: pair_request) do %>
+          <%= render TableCellComponent.new(container_link: pair_request, classes: 'table-cell') do %>
             <%= pair_request.status.capitalize %>
           <% end %>
 
-          <%= render(TableCellComponent.new(hidden_on_mobile: true)) do %>
+          <%= render(TableCellComponent.new(classes: 'hidden sm:table-cell')) do %>
             <%= render PairRequest::StatusButtonsComponent.new(pair_request:, current_user:) %>
             <%= render Feedback::EditButtonComponent.new(
               feedback: pair_request.authored_feedback_for(current_user),

--- a/app/views/pair_requests/index.html.erb
+++ b/app/views/pair_requests/index.html.erb
@@ -6,16 +6,16 @@
   <div class="table w-full border-2 border-black text-md md:text-base">
     <div class="table-header-group">
       <div class="table-row font-bold bg-primary divide-x-2 divide-black text-white">
-        <%= render TableCellComponent.new(classes: 'table-cell text-center') do %>
+        <%= render TableCellComponent.new(class_names: 'table-cell text-center') do %>
           Partner
         <% end %>
-        <%= render TableCellComponent.new(classes: 'table-cell text-center') do %>
+        <%= render TableCellComponent.new(class_names: 'table-cell text-center') do %>
           When
         <% end %>
-        <%= render TableCellComponent.new(classes: 'table-cell text-center') do %>
+        <%= render TableCellComponent.new(class_names: 'table-cell text-center') do %>
           Status
         <% end %>
-        <%= render TableCellComponent.new(classes: 'hidden sm:table-cell text-center') do %>
+        <%= render TableCellComponent.new(class_names: 'hidden sm:table-cell text-center') do %>
           Actions
         <% end %>
       </div>
@@ -36,7 +36,7 @@
             <%= pair_request.status.capitalize %>
           <% end %>
 
-          <%= render(TableCellComponent.new(classes: 'hidden sm:table-cell')) do %>
+          <%= render(TableCellComponent.new(class_names: 'hidden sm:table-cell')) do %>
             <%= render PairRequest::StatusButtonsComponent.new(pair_request:, current_user:) %>
             <%= render Feedback::EditButtonComponent.new(
               feedback: pair_request.authored_feedback_for(current_user),

--- a/app/views/pair_requests/index.html.erb
+++ b/app/views/pair_requests/index.html.erb
@@ -6,10 +6,12 @@
   <div class="table w-full border-2 border-black text-md md:text-base">
     <div class="table-header-group">
       <div class="table-row font-bold bg-neutral-400 divide-x-2 divide-black">
-        <div class="table-cell text-left p-1">Partner</div>
-        <div class="table-cell text-left p-1">When</div>
-        <div class="table-cell text-left p-1">Status</div>
-        <div class="text-left p-1 hidden sm:table-cell">Actions</div>
+        <%= render TableCellComponent.new do %>Partner<% end %>
+        <%= render TableCellComponent.new do %>When<% end %>
+        <%= render TableCellComponent.new do %>Status<% end %>
+        <%= render TableCellComponent.new(classes: 'hidden sm:table-cell') do %>
+          Actions
+        <% end %>
       </div>
     </div>
     <div class="table-row-group">

--- a/app/views/pair_requests/index.html.erb
+++ b/app/views/pair_requests/index.html.erb
@@ -5,7 +5,7 @@
 <div class="p-2">
   <div class="table w-full border-2 border-black text-md md:text-base">
     <div class="table-header-group">
-      <div class="table-row font-bold bg-neutral-400 divide-x-2 divide-black">
+      <div class="table-row font-bold bg-primary divide-x-2 divide-black text-white">
         <%= render TableCellComponent.new(classes: 'table-cell text-center') do %>
           Partner
         <% end %>

--- a/app/views/pair_requests/index.html.erb
+++ b/app/views/pair_requests/index.html.erb
@@ -9,7 +9,7 @@
         <div class="table-cell text-left p-1">Partner</div>
         <div class="table-cell text-left p-1">When</div>
         <div class="table-cell text-left p-1">Status</div>
-        <div class="table-cell text-left p-1">Actions</div>
+        <div class="text-left p-1 hidden md:table-cell">Actions</div>
       </div>
     </div>
     <div class="table-row-group">
@@ -28,7 +28,7 @@
             <%= pair_request.status.capitalize %>
           <% end %>
 
-          <%= render(TableCellComponent.new) do %>
+          <%= render(TableCellComponent.new(hidden_on_mobile: true)) do %>
             <%= render PairRequest::StatusButtonsComponent.new(pair_request:, current_user:) %>
             <%= render Feedback::EditButtonComponent.new(
               feedback: pair_request.authored_feedback_for(current_user),

--- a/app/views/pair_requests/index.html.erb
+++ b/app/views/pair_requests/index.html.erb
@@ -6,10 +6,16 @@
   <div class="table w-full border-2 border-black text-md md:text-base">
     <div class="table-header-group">
       <div class="table-row font-bold bg-neutral-400 divide-x-2 divide-black">
-        <%= render TableCellComponent.new do %>Partner<% end %>
-        <%= render TableCellComponent.new do %>When<% end %>
-        <%= render TableCellComponent.new do %>Status<% end %>
-        <%= render TableCellComponent.new(classes: 'hidden sm:table-cell') do %>
+        <%= render TableCellComponent.new(classes: 'table-cell text-center') do %>
+          Partner
+        <% end %>
+        <%= render TableCellComponent.new(classes: 'table-cell text-center') do %>
+          When
+        <% end %>
+        <%= render TableCellComponent.new(classes: 'table-cell text-center') do %>
+          Status
+        <% end %>
+        <%= render TableCellComponent.new(classes: 'hidden sm:table-cell text-center') do %>
           Actions
         <% end %>
       </div>


### PR DESCRIPTION
This is a draft proposal for how we might hide the action column on mobile to improve readability. Not sure if this is a best practice when using view components, but I figured I'd throw up a draft and see what y'all think.

Before:
<img width="318" alt="Screen Shot 2023-06-16 at 3 48 51 PM" src="https://github.com/agency-of-learning/PairApp/assets/2447409/8316d341-2b55-45d8-8539-4e51f1158685">

After:
<img width="320" alt="Screen Shot 2023-06-16 at 3 47 51 PM" src="https://github.com/agency-of-learning/PairApp/assets/2447409/613cb1d0-8d05-485d-9303-5e4d1f708404">

