### PR TITLE
Add placeholder content for incomplete feedback

### DIFF
--- a/app/components/feedback/container_component.html.erb
+++ b/app/components/feedback/container_component.html.erb
@@ -5,8 +5,14 @@
       <%= link_to "Edit", edit_feedback_path(feedback), class: 'btn btn-primary btn-sm capitalize' %>
     <% end %>
   </div>
-  <div class="p-2">
-    <p><span class="font-bold">Rating:</span> <%= feedback.overall_rating %>/10</p>
+  <div>
+    <% if feedback.completed? %>
+      <div class="p-2">
+        <p><span class="font-bold">Rating:</span> <%= feedback.overall_rating %>/10</p>
+      </div>
+      <%= render Feedback::QuestionComponent.with_collection(questions) %>
+    <% else %>
+      <p class="p-4">Awaiting completion of feedback.</p>
+    <% end %>
   </div>
-  <%= render Feedback::QuestionComponent.with_collection(questions) %>
 </div>

--- a/spec/components/feedback/container_component_spec.rb
+++ b/spec/components/feedback/container_component_spec.rb
@@ -4,8 +4,9 @@ require 'rails_helper'
 
 RSpec.describe Feedback::ContainerComponent, type: :component do
   let(:current_user) { create(:user) }
-  let(:authored_feedback) { create(:feedback, author: current_user) }
-  let(:received_feedback) { create(:feedback, receiver: current_user) }
+  let(:authored_feedback) { create(:feedback, author: current_user, status:) }
+  let(:received_feedback) { create(:feedback, receiver: current_user, status:) }
+  let(:status) { :draft }
 
   context 'when no feedback is passed in' do
     it 'renders nothing' do
@@ -40,6 +41,25 @@ RSpec.describe Feedback::ContainerComponent, type: :component do
       render_inline(described_class.new(feedback: received_feedback, current_user:))
 
       expect(page).not_to have_link('Edit')
+    end
+  end
+
+  context 'when the feedback is not completed' do
+    it "renders 'Awaiting completion of feedback.'" do
+      render_inline(described_class.new(feedback: authored_feedback, current_user:))
+
+      expect(page).to have_content('Awaiting completion of feedback.')
+    end
+  end
+
+  context 'when the feedback is completed' do
+    let(:status) { :completed }
+
+    it 'renders the feedback rating out of 10' do
+      render_inline(described_class.new(feedback: authored_feedback, current_user:))
+
+      expected_rating = authored_feedback.overall_rating
+      expect(page).to have_content("#{expected_rating}/10")
     end
   end
 end


### PR DESCRIPTION
## This PR
- Adds some placeholder content on pair request show page for when feedback is incomplete

## Screenshots
Mobile:
![Selection_181](https://github.com/agency-of-learning/PairApp/assets/88392688/a1b8fb6a-c978-4ba7-8f03-de3f7a533868)

Desktop:
![image](https://github.com/agency-of-learning/PairApp/assets/88392688/78fcaad3-9da4-4a1f-b11d-28cd49857d68)
