### PR TITLE
test ci on github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
         run: |
           sudo apt-get install -y -qq libvips
           yarn install --frozen-lockfile
-          yarn playwright install
 
       - name: Linter Check
         run: bundle exec rubocop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           yarn install --frozen-lockfile
 
       - name: Linter Check
-        run: bundle exec rubocop --lint
+        run: rubocop --lint
 
       - name: Run tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           yarn install --frozen-lockfile
 
       - name: Linter Check
-        run: rubocop --lint
+        run: bundle exec rubocop --lint
 
       - name: Run tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        ports: ["5432:5432"]
+      redis:
+        image: redis
+        ports: ["6379:6379"]
+        options: --entrypoint redis-server
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler: default
+          bundler-cache: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          cache: yarn
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y -qq libvips
+          yarn install --frozen-lockfile
+          yarn playwright install
+
+      - name: Linter Check
+        run: bundle exec rubocop
+
+      - name: Run tests
+        env:
+          DATABASE_URL: postgres://postgres:password@localhost:5432/test
+          REDIS_URL: redis://localhost:6379/0
+          RAILS_ENV: test
+          PG_USER: postgres
+        run: |
+          bin/rails test:prepare
+          bin/rails db:test:prepare
+          bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           yarn install --frozen-lockfile
 
       - name: Linter Check
-        run: bundle exec rubocop
+        run: bundle exec rubocop --lint
 
       - name: Run tests
         env:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - db/**/*
     - bin/**/*
     - Guardfile
+    - vendor/bundle/**/*
   DisplayCopNames: false
   DisplayStyleGuide: true
   StyleGuideCopsOnly: false


### PR DESCRIPTION
Adds CI using github actions. Need to exclude the vendor gems in order to run our rubocop workflow (see https://github.com/rubocop/rubocop/issues/9832)

To see tests passing, look at the pull request on my personal repo: https://github.com/afogel/PairApp/pull/2