### PR TITLE
Add Cancelled State

### DIFF
--- a/app/components/pair_request/status_buttons_component.html.erb
+++ b/app/components/pair_request/status_buttons_component.html.erb
@@ -24,3 +24,12 @@
     form_class: "w-fit"
   ) %>
 <% end %>
+
+<% if policy(:cancel).create? %>
+  <%= button_to(
+    "Cancel",
+    pair_request_cancellations_path(pair_request),
+    class: "btn btn-error capitalize #{STYLES[style]}",
+    form_class: "w-fit"
+  ) %>
+<% end %>

--- a/app/components/pair_request/status_buttons_component.rb
+++ b/app/components/pair_request/status_buttons_component.rb
@@ -4,7 +4,8 @@ class PairRequest::StatusButtonsComponent < ViewComponent::Base
   STATUS_POLICIES = {
     accept: PairRequest::AcceptancePolicy,
     reject: PairRequest::RejectionPolicy,
-    complete: PairRequest::CompletionPolicy
+    complete: PairRequest::CompletionPolicy,
+    cancel: PairRequest::CancellationPolicy
   }.freeze
 
   STYLES = {

--- a/app/controllers/pair_requests/cancellations_controller.rb
+++ b/app/controllers/pair_requests/cancellations_controller.rb
@@ -1,0 +1,10 @@
+class PairRequests::CancellationsController < ApplicationController
+  def create
+    @pair_request = PairRequest.find(params[:pair_request_id])
+    authorize @pair_request, policy_class: PairRequest::CancellationPolicy
+    @pair_request.cancelled!
+
+    flash[:notice] = 'You have cancelled this pair request.'
+    redirect_back_or_to pair_requests_path
+  end
+end

--- a/app/models/pair_request.rb
+++ b/app/models/pair_request.rb
@@ -43,9 +43,10 @@ class PairRequest < ApplicationRecord
     rejected: 1,
     accepted: 2,
     expired: 3,
-    completed: 4
+    completed: 4,
+    cancelled: 5
   }
-  STATUS_PRIORITIES = %i[pending accepted completed expired rejected].freeze
+  STATUS_PRIORITIES = %i[pending accepted completed cancelled expired rejected].freeze
 
   scope :order_by_date, -> { order(:when) }
   scope :order_by_status, -> { in_order_of(:status, STATUS_PRIORITIES) }

--- a/app/policies/pair_request/cancellation_policy.rb
+++ b/app/policies/pair_request/cancellation_policy.rb
@@ -1,0 +1,9 @@
+class PairRequest::CancellationPolicy < ApplicationPolicy
+  alias_method :pair_request, :record
+
+  def create?
+    user == pair_request.author && (
+      pair_request.pending? || pair_request.accepted?
+    )
+  end
+end

--- a/app/policies/pair_request/rejection_policy.rb
+++ b/app/policies/pair_request/rejection_policy.rb
@@ -2,12 +2,6 @@ class PairRequest::RejectionPolicy < ApplicationPolicy
   alias_method :pair_request, :record
 
   def create?
-    user_is_owner? && (pair_request.pending? || pair_request.accepted?)
-  end
-
-  private
-
-  def user_is_owner?
-    pair_request.author == user || pair_request.invitee == user
+    pair_request.invitee == user && (pair_request.pending? || pair_request.accepted?)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
       resources :acceptances, only: :create
       resources :completions, only: :create
       resources :rejections, only: :create
+      resources :cancellations, only: :create
     end
   end
 

--- a/spec/components/pair_request/status_buttons_component_spec.rb
+++ b/spec/components/pair_request/status_buttons_component_spec.rb
@@ -3,35 +3,64 @@
 require 'rails_helper'
 
 RSpec.describe PairRequest::StatusButtonsComponent, type: :component do
-  let!(:current_user) { create(:user) }
-  let!(:pending_request) { create(:pair_request, invitee: current_user) }
-  let!(:completed_request) { create(:pair_request, invitee: current_user, status: :completed) }
-  let!(:request_awaiting_completion) do
-    create(:pair_request, author: current_user, when: 5.minutes.ago, status: :accepted)
-  end
+  let(:invitee) { create(:user) }
+  let(:author) { create(:user) }
 
-  context 'with a pair request that can be accepted or rejected' do
-    it 'renders an Accept button and a Reject button' do
-      render_inline(described_class.new(pair_request: pending_request, current_user:))
+  context 'when the current user is the invitee' do
+    let(:current_user) { invitee }
 
-      expect(page).to have_button('Accept')
-      expect(page).to have_button('Reject')
+    context 'with a pair request that can be accepted or rejected' do
+      it 'renders an Accept button and a Reject button' do
+        pending_request = create(:pair_request, invitee: current_user)
+        render_inline(described_class.new(pair_request: pending_request, current_user:))
+
+        expect(page).to have_button('Accept')
+        expect(page).to have_button('Reject')
+      end
+    end
+
+    context 'with a pair request that is accepted' do
+      it 'renders the Reject button' do
+        accepted_request = create(:pair_request, invitee: current_user, status: :accepted)
+        render_inline(described_class.new(pair_request: accepted_request, current_user:))
+
+        expect(page).to have_button('Reject')
+      end
+    end
+
+    context 'with a pair request that is completed' do
+      it 'renders nothing' do
+        completed_request = create(:pair_request, invitee: current_user, status: :completed)
+        render_inline(described_class.new(pair_request: completed_request, current_user:))
+
+        expect(page).not_to have_selector('body')
+      end
     end
   end
 
-  context 'with a pair request that is completed' do
-    it 'renders nothing' do
-      render_inline(described_class.new(pair_request: completed_request, current_user:))
+  context 'when the current user is the author' do
+    let(:current_user) { author }
 
-      expect(page).not_to have_selector('body')
+    context 'with a request that can be completed' do
+      it 'renders a Complete button' do
+        request_awaiting_completion = create(:pair_request,
+          author: current_user,
+          when: 5.minutes.ago,
+          status: :accepted)
+
+        render_inline(described_class.new(pair_request: request_awaiting_completion, current_user:))
+        expect(page).to have_button('Complete')
+        expect(page).to have_button('Cancel')
+      end
     end
-  end
 
-  context 'with a request that can be completed' do
-    it 'renders a Complete button' do
-      render_inline(described_class.new(pair_request: request_awaiting_completion, current_user:))
+    context 'with a request that is pending' do
+      it 'renders a Cancel button' do
+        pending_request = create(:pair_request, author: current_user)
 
-      expect(page).to have_button('Complete')
+        render_inline(described_class.new(pair_request: pending_request, current_user:))
+        expect(page).to have_button('Cancel')
+      end
     end
   end
 end

--- a/spec/policies/acceptance_policy_spec.rb
+++ b/spec/policies/acceptance_policy_spec.rb
@@ -4,25 +4,28 @@ RSpec.describe PairRequest::AcceptancePolicy do
 
   let(:user) { build(:user) }
   let(:invitee) { build(:user) }
-  let(:pending_pair_request) { build(:pair_request, invitee: invitee) }
-  let(:expired_pair_request) { build(:pair_request, status: :expired, invitee:)}
-  let(:accepted_pair_request) { build(:pair_request, status: :accepted, invitee: invitee) }
+  let(:pending_pair_request) { build(:pair_request, invitee:) }
+  let(:expired_pair_request) { build(:pair_request, status: :expired, invitee:) }
+  let(:accepted_pair_request) { build(:pair_request, status: :accepted, invitee:) }
+  let(:cancelled_pair_request) { build(:pair_request, status: :cancelled, invitee:) }
 
   permissions :create? do
-    it 'grants access if the user is the invitee' do
-      expect(subject).to permit(invitee, pending_pair_request)
+    context 'user is the invitee' do
+      it 'grants access if the request is pending' do
+        expect(subject).to permit(invitee, pending_pair_request)
+      end
+
+      it 'denies access if the request is expired' do
+        expect(subject).not_to permit(invitee, expired_pair_request)
+      end
+
+      it 'denies access if the request is cancelled' do
+        expect(subject).not_to permit(invitee, cancelled_pair_request)
+      end
     end
 
     it 'denies access if the user is not the invitee' do
       expect(subject).not_to permit(user, pending_pair_request)
-    end
-
-    it 'denies access if pair_request is expired' do
-      expect(subject).not_to permit(invitee, expired_pair_request)
-    end
-
-    it 'grants access if user is the invitee and request is pending' do
-      expect(subject).to permit(invitee, pending_pair_request)
     end
   end
 end

--- a/spec/policies/cancellation_policy_spec.rb
+++ b/spec/policies/cancellation_policy_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+RSpec.describe PairRequest::CancellationPolicy do
+  subject { described_class }
+
+  let(:user) { build(:user) }
+  let(:author) { build(:user) }
+  let(:pending_pair_request) { build(:pair_request, author:) }
+  let(:expired_pair_request) { build(:pair_request, status: :expired, author:) }
+  let(:accepted_pair_request) { build(:pair_request, status: :accepted, author:) }
+  let(:rejected_pair_request) { build(:pair_request, status: :rejected, author:) }
+  let(:completed_pair_request) { build(:pair_request, status: :completed, author:) }
+  let(:cancelled_pair_request) { build(:pair_request, status: :cancelled, author:) }
+
+  permissions :create? do
+    context 'user is the author' do
+      it 'grants access if the request is pending' do
+        expect(subject).to permit(author, pending_pair_request)
+      end
+
+      it 'grants access if the request is accepted' do
+        expect(subject).to permit(author, accepted_pair_request)
+      end
+
+      it 'denies access if the request is rejected' do
+        expect(subject).not_to permit(author, rejected_pair_request)
+      end
+
+      it 'denies access if the request is expired' do
+        expect(subject).not_to permit(author, expired_pair_request)
+      end
+
+      it 'denies access if the request is completed' do
+        expect(subject).not_to permit(author, completed_pair_request)
+      end
+
+      it 'denies access if the request is cancelled' do
+        expect(subject).not_to permit(author, cancelled_pair_request)
+      end
+    end
+
+    it 'denies access if the user is not the author' do
+      expect(subject).not_to permit(user, pending_pair_request)
+    end
+  end
+end


### PR DESCRIPTION
Closes #53.

Context:
This PR adds in a canceled state that only pair request authors can use on pending or accepted pair requests. 

To accomplish this, the PR:
- adds an enum status onto pair request
- updates the status priorities
- adds a canceled policy
- updates the status button component
- create a namespaced pair_request cancelations controller
- tests all the features above

In addition, the PR also modifies the rejection policy such that an author can no longer reject a pair request.