### PR TITLE
Flash message form errors

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,12 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-/*
-
-@layer components {
-  .btn-primary {
-    @apply py-2 px-4 bg-blue-200;
-  }
+.field_with_errors {
+  @apply flex [&>input]:input-error;
 }
-
-*/

--- a/app/components/flash_component.html.erb
+++ b/app/components/flash_component.html.erb
@@ -1,0 +1,17 @@
+<div class="alert shadow-lg mb-8 <%= theme %>" role="alert" data-controller="alert" data-alert-show-class="translate-x-0 opacity-100" data-alert-hide-class="translate-x-full opacity-0">
+  <% if type == :form_errors %>
+    <div class="flex flex-col items-start">
+      <h3 class="text-xl">Error! Please fix inputs</h3>
+      <% message.each do |error| %>
+        <p><%= error %></p>
+      <% end %>
+    </div>
+  <% else %>
+    <%= message %>
+  <% end %>
+  <button data-action="alert#close" class="inline-flex text-white focus:outline-none focus:text-gray-300 transition ease-in-out duration-150">
+    <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/>
+    </svg>
+  </button>
+</div>

--- a/app/components/flash_component.rb
+++ b/app/components/flash_component.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class FlashComponent < ViewComponent::Base
+  TYPE_THEMES = {
+    notice: 'success',
+    alert: 'error',
+    form_errors: 'error'
+  }.freeze
+
+  def initialize(type:, message:)
+    @type = type.to_sym
+    @message = message
+  end
+
+  attr_reader :type, :message
+
+  def theme
+    "alert-#{TYPE_THEMES.fetch(type)}"
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,24 +2,26 @@ class ApplicationController < ActionController::Base
   include Pundit::Authorization
   include ApplicationHelper
 
+  add_flash_types :form_errors
+
   before_action :authenticate_user!
 
   before_action :configure_permitted_parameters, if: :devise_controller?
-
 
   # PaperTrail helper for getting current_user
   before_action :set_paper_trail_whodunnit
 
   around_action :set_time_zone, if: :current_user
 
-
   protected
+
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:accept_invitation, keys: [:time_zone])
     devise_parameter_sanitizer.permit(:account_update, keys: [:time_zone])
   end
-  
+
   private
+
   def set_time_zone(&)
     Time.use_zone(current_user.time_zone, &)
   end

--- a/app/controllers/pair_requests_controller.rb
+++ b/app/controllers/pair_requests_controller.rb
@@ -26,11 +26,16 @@ class PairRequestsController < ApplicationController
         format.turbo_stream do
           @persisted_pair_request = @pair_request
           @pair_request = PairRequest.new
+          flash.now[:notice] = 'Pair request was successfully created.'
           render :create
         end
       else
         format.html { render :new, status: :unprocessable_entity }
-        format.turbo_stream { render :create }
+        # format.turbo_stream { render :create }
+        format.turbo_stream do
+          flash.now[:form_errors] = @pair_request.errors.full_messages
+          render :create
+        end
       end
     end
   end

--- a/app/controllers/pair_requests_controller.rb
+++ b/app/controllers/pair_requests_controller.rb
@@ -19,23 +19,15 @@ class PairRequestsController < ApplicationController
 
     respond_to do |format|
       if @pair_request.save
-        format.html do
-          redirect_to pair_request_url(@pair_request),
-            notice: 'Pair request was successfully created.'
-        end
+        format.html { redirect_to @pair_request, notice: 'Pair request was successfully created.' }
         format.turbo_stream do
           @persisted_pair_request = @pair_request
           @pair_request = PairRequest.new
           flash.now[:notice] = 'Pair request was successfully created.'
-          render :create
         end
       else
         format.html { render :new, status: :unprocessable_entity }
-        # format.turbo_stream { render :create }
-        format.turbo_stream do
-          flash.now[:form_errors] = @pair_request.errors.full_messages
-          render :create
-        end
+        format.turbo_stream { flash.now[:form_errors] = @pair_request.errors.full_messages }
       end
     end
   end

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,19 +1,3 @@
-<% if alert %>
-  <div class="alert alert-error shadow-lg mb-8" role="alert" data-controller="alert" data-alert-show-class="translate-x-0 opacity-100" data-alert-hide-class="translate-x-full opacity-0">
-    <%= alert %>
-    <button data-action="alert#close" class="inline-flex text-white focus:outline-none focus:text-gray-300 transition ease-in-out duration-150">
-      <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-        <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/>
-      </svg>
-    </button>
-  </div>
-<% elsif notice %>
-  <div class="alert alert-success shadow-lg mb-8" role="alert" data-controller="alert" data-alert-show-class="translate-x-0 opacity-100" data-alert-hide-class="translate-x-full opacity-0">
-    <%= notice %>
-    <button data-action="alert#close" class="inline-flex text-white focus:outline-none focus:text-gray-300 transition ease-in-out duration-150">
-      <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-        <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/>
-      </svg>
-    </button>
-  </div>
+<% flash.each do |type, message| %>
+  <%= render FlashComponent.new(type: type, message: message) %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,9 @@
     <div class="min-h-full">
       <%= render "layouts/navbar" %>
       <div class="container mx-auto">
-        <%= render "layouts/flash" %>
+        <div id="flash">
+          <%= render "layouts/flash" %>
+        </div>
         <%= yield %>
       </div>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
     <div class="min-h-full">
       <%= render "layouts/navbar" %>
       <div class="container mx-auto">
-        <div id="flash">
+        <div id="flash" class="empty:hidden px-4">
           <%= render "layouts/flash" %>
         </div>
         <%= yield %>

--- a/app/views/pair_requests/_form.html.erb
+++ b/app/views/pair_requests/_form.html.erb
@@ -1,17 +1,5 @@
 <%= turbo_frame_tag "new_request_form" do %>
   <%= form_with(model: pair_request, class: 'p-4 w-full mx-auto border-2 border-primary rounded-md flex flex-col') do |form| %>
-    <% if pair_request.errors.any? %>
-      <div class="alert alert-error flex flex-col items-start my-4">
-        <%= pluralize(pair_request.errors.count, "error") %> prohibited this pair   request from being saved:
-        <ul>
-          <% pair_request.errors.each do |error| %>
-            <li class='font-bold'>
-              <%= error.full_message %>
-            </li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
     <div id="form-container" class='flex flex-col space-y-4 xl:space-y-0 xl:max-w-full xl:inline-flex xl:justify-around xl:space-x-8 xl:flex-row'>
       <div class="flex justify-between space-x-4 align-middle">
         <%= form.label :invitee_id, class: "label label-text" %>
@@ -23,7 +11,7 @@
 
       <div class="flex justify-between space-x-4 align-middle">
         <%= form.label :when, class: "label label-text" %>
-        <%= form.datetime_field :when, required: true %>
+        <%= form.datetime_field :when, required: true, class: "input input-primary input-md" %>
       </div>
 
       <div class="flex justify-between space-x-4 align-middle">

--- a/app/views/pair_requests/_table_row.html.erb
+++ b/app/views/pair_requests/_table_row.html.erb
@@ -1,0 +1,21 @@
+<div class="table-row odd:bg-white even:bg-neutral-100 hover:bg-neutral-200 divide-x-2 divide-black">
+  <%= render TableCellComponent.new(container_link: pair_request) do %>
+    <%= pair_request.partner_for(current_user).email %>
+  <% end %>
+
+  <%= render TableCellComponent.new(container_link: pair_request) do %>
+    <%= format_request_date(pair_request) %>
+  <% end %>
+
+  <%= render TableCellComponent.new(container_link: pair_request) do %>
+    <%= pair_request.status.capitalize %>
+  <% end %>
+
+  <%= render(TableCellComponent.new) do %>
+    <%= render PairRequest::StatusButtonsComponent.new(pair_request:, current_user:, style: :link) %>
+    <%= render Feedback::EditButtonComponent.new(
+      feedback: pair_request.authored_feedback_for(current_user),
+      current_user:
+    ) %>
+  <% end %>
+</div>

--- a/app/views/pair_requests/_table_row.html.erb
+++ b/app/views/pair_requests/_table_row.html.erb
@@ -11,7 +11,7 @@
     <%= pair_request.status.capitalize %>
   <% end %>
 
-  <%= render(TableCellComponent.new) do %>
+  <%= render(TableCellComponent.new(class_names: 'hidden sm:table-cell')) do %>
     <%= render PairRequest::StatusButtonsComponent.new(pair_request:, current_user:, style: :link) %>
     <%= render Feedback::EditButtonComponent.new(
       feedback: pair_request.authored_feedback_for(current_user),

--- a/app/views/pair_requests/create.turbo_stream.erb
+++ b/app/views/pair_requests/create.turbo_stream.erb
@@ -6,27 +6,7 @@
 
 <% if @persisted_pair_request %>
   <%= turbo_stream.prepend 'my-pair-requests' do %>
-    <div class="table-row odd:bg-white even:bg-neutral-100 hover:bg-neutral-200 divide-x-2 divide-black">
-        <%= render TableCellComponent.new(container_link: @persisted_pair_request) do %>
-          <%= @persisted_pair_request.partner_for(current_user).email %>
-        <% end %>
-
-        <%= render TableCellComponent.new(container_link: @persisted_pair_request) do %>
-          <%= format_request_date(@persisted_pair_request) %>
-        <% end %>
-
-        <%= render TableCellComponent.new(container_link: @persisted_pair_request) do %>
-          <%= @persisted_pair_request.status.capitalize %>
-        <% end %>
-
-        <%= render(TableCellComponent.new) do %>
-          <%= render PairRequest::StatusButtonsComponent.new(pair_request: @persisted_pair_request, current_user:) %>
-          <%= render Feedback::EditButtonComponent.new(
-            feedback: @persisted_pair_request.authored_feedback_for(current_user),
-            current_user:
-          ) %>
-        <% end %>
-      </div>
+    <%= render 'table_row', pair_request: @persisted_pair_request %>
   <% end %>
 <% end %>
 

--- a/app/views/pair_requests/create.turbo_stream.erb
+++ b/app/views/pair_requests/create.turbo_stream.erb
@@ -1,7 +1,8 @@
+<%= turbo_stream.update "flash", partial: "layouts/flash" %>
+
 <%= turbo_stream.update 'new_request_form' do %>
   <%= render 'form', pair_request: @pair_request %>
 <% end %>
-
 
 <% if @persisted_pair_request %>
   <%= turbo_stream.prepend 'my-pair-requests' do %>

--- a/app/views/pair_requests/index.html.erb
+++ b/app/views/pair_requests/index.html.erb
@@ -1,7 +1,7 @@
 <h1 class="text-2xl font-bold mb-4 text-center">My Requests</h1>
 
 <div class="p-4">
-  <%= render 'form', pair_request: @pair_request  %>
+  <%= render 'form', pair_request: @pair_request %>
 </div>
 
 <div class="p-2">
@@ -24,28 +24,7 @@
     </div>
     <div class="table-row-group" id='my-pair-requests'>
       <% @pair_requests.each do |pair_request| %>
-        <div class="table-row odd:bg-white even:bg-neutral-100 hover:bg-neutral-200 divide-x-2 divide-black">
-
-          <%= render TableCellComponent.new(container_link: pair_request) do %>
-            <%= pair_request.partner_for(current_user).email %>
-          <% end %>
-
-          <%= render TableCellComponent.new(container_link: pair_request) do %>
-            <%= format_request_date(pair_request) %>
-          <% end %>
-
-          <%= render TableCellComponent.new(container_link: pair_request) do %>
-            <%= pair_request.status.capitalize %>
-          <% end %>
-
-          <%= render(TableCellComponent.new(class_names: 'hidden sm:table-cell')) do %>
-            <%= render PairRequest::StatusButtonsComponent.new(pair_request:, current_user:, style: :link) %>
-            <%= render Feedback::EditButtonComponent.new(
-              feedback: pair_request.authored_feedback_for(current_user),
-              current_user:
-            ) %>
-          <% end %>
-        </div>
+        <%= render "table_row", pair_request: %>
       <% end %>
     </div>
   </div>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -22,5 +22,11 @@ module.exports = {
     require('@tailwindcss/aspect-ratio'),
     require('@tailwindcss/typography'),
     require("daisyui"),
-  ]
+  ],
+  purge: {
+    safelist: [
+      'alert-error',
+      'alert-success',
+    ]
+  }
 }

--- a/spec/components/flash_component_spec.rb
+++ b/spec/components/flash_component_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FlashComponent, type: :component do
+  context 'with an alert type message' do
+    it 'renders the message with an alert-error class' do
+      render_inline(described_class.new(type: :alert, message: 'This is an alert'))
+
+      expect(page).to have_content('This is an alert')
+      expect(page).to have_css('.alert-error')
+    end
+  end
+
+  context 'with a notice type message' do
+    it 'renders the message with a alert-success class' do
+      render_inline(described_class.new(type: :notice, message: 'This is a notice'))
+
+      expect(page).to have_content('This is a notice')
+      expect(page).to have_css('.alert-success')
+    end
+  end
+
+  context 'with a form_errors types message' do
+    it 'renders the messages with an alert-error class' do
+      messages = ['form error 1', 'form error 2']
+      render_inline(described_class.new(type: :form_errors, message: messages))
+
+      expect(page).to have_content('Error! Please fix inputs')
+      expect(page).to have_content('form error 1')
+      expect(page).to have_content('form error 2')
+      expect(page).to have_css('.alert-error')
+    end
+  end
+end


### PR DESCRIPTION
## This PR:
- Adds flash messages for form errors
- Adds a flash component to handle logical display of flash messages
- Extracts pair request table row to a partial (was being used in two places)
- Style input fields from inputs that have errors
- Add this new functionality for pair request index form

## Issue
Closes #102 

## Screenshots
#### Desktop Success
![Selection_184](https://github.com/agency-of-learning/PairApp/assets/88392688/90fdd521-1e8d-4704-9f87-f197e7aa9bcc)

####  Desktop Failure
![Selection_185](https://github.com/agency-of-learning/PairApp/assets/88392688/4d5911b7-2631-4200-86e9-52545049753d)

#### Mobile Success
![image](https://github.com/agency-of-learning/PairApp/assets/88392688/d09fc909-b951-4423-aeb9-6b036bc64466)

#### Mobile Failure
![Selection_186](https://github.com/agency-of-learning/PairApp/assets/88392688/101fc13b-ef28-4353-9628-a02f1f071696)

#### Errors on Multiple Fields
![image](https://github.com/agency-of-learning/PairApp/assets/88392688/246a347d-cbfe-452a-804c-8135b979c35e)

## Misc. Comments
- The changes to `tailwind.config.js`: Tailwind purges any utilities it can't find in the source markup as a way of optimizing its bundle size. The only place in the source code we're using the `alert-<something>` utilities are in the flash components and the exact class to use is programmatically determined rather than explicitly in the source. So in order to keep them from being purged, I have to explicitly tell Tailwind that we're using them.