### PR TITLE
Display link to create a 'New Standup Group' only for Admins

### DIFF
--- a/app/controllers/standup_meeting_groups_controller.rb
+++ b/app/controllers/standup_meeting_groups_controller.rb
@@ -12,6 +12,9 @@ class StandupMeetingGroupsController < ApplicationController
 
   def new
     @standup_meeting_group = StandupMeetingGroup.new
+    authorize(@standup_meeting_group)
+  rescue Pundit::NotAuthorizedError
+    redirect_to standup_meeting_groups_url, notice: 'Must be an admin to create a new standup meeting group'
   end
 
   def edit; end

--- a/app/policies/standup_meeting_group_policy.rb
+++ b/app/policies/standup_meeting_group_policy.rb
@@ -11,10 +11,6 @@ class StandupMeetingGroupPolicy < ApplicationPolicy
     user.admin?
   end
 
-  def new?
-    user.admin?
-  end
-
   def update?
     user.admin?
   end

--- a/app/policies/standup_meeting_group_policy.rb
+++ b/app/policies/standup_meeting_group_policy.rb
@@ -11,7 +11,7 @@ class StandupMeetingGroupPolicy < ApplicationPolicy
     user.admin?
   end
 
-  def edit?
+  def new?
     user.admin?
   end
 

--- a/app/views/standup_meeting_groups/index.html.erb
+++ b/app/views/standup_meeting_groups/index.html.erb
@@ -1,14 +1,24 @@
 <h1>Standup Meeting Groups</h1>
 
+<% if policy(:standup_meeting_group).new? %>
+<%= link_to "New Standup Meeting Group", new_standup_meeting_group_path %>
+<% end %>
+
 <div class="p-2 border-black border-2" id="new_standup_meeting_group">
   <%= render 'form', standup_meeting_group: StandupMeetingGroup.new %>
+
+<div id="standup_meeting_group">
+  <% @standup_meeting_groups.each do |standup_meeting_group| %>
+    <%= render standup_meeting_group %>
+
+    <p>
+      <%= link_to "Show this standup meeting group", standup_meeting_group %>
+    </p>
+  <% end %>
 </div>
 
 <hr class="mb-5 mt-5 border-b-2">
 
-
 <ul role="list" id="standup_meeting_group_list">
   <%= render partial: 'standup_meeting_group_list_item', collection: @standup_meeting_groups, as: :standup_meeting_group %>
 </ul>
-
-

--- a/app/views/standup_meeting_groups/index.html.erb
+++ b/app/views/standup_meeting_groups/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Standup Meeting Groups</h1>
 
 <% if policy(:standup_meeting_group).new? %>
-<%= link_to "New Standup Meeting Group", new_standup_meeting_group_path %>
+  <%= link_to "New Standup Meeting Group", new_standup_meeting_group_path %>
 <% end %>
 
 <div class="p-2 border-black border-2" id="new_standup_meeting_group">

--- a/app/views/standup_meeting_groups/index.html.erb
+++ b/app/views/standup_meeting_groups/index.html.erb
@@ -7,3 +7,10 @@
 <div class="p-2 border-black border-2" id="new_standup_meeting_group">
   <%= render 'form', standup_meeting_group: StandupMeetingGroup.new %>
 </div>
+
+<hr class="mb-5 mt-5 border-b-2">
+
+
+<ul role="list" id="standup_meeting_group_list">
+  <%= render partial: 'standup_meeting_group_list_item', collection: @standup_meeting_groups, as: :standup_meeting_group %>
+</ul>

--- a/app/views/standup_meeting_groups/index.html.erb
+++ b/app/views/standup_meeting_groups/index.html.erb
@@ -1,24 +1,9 @@
 <h1>Standup Meeting Groups</h1>
 
 <% if policy(:standup_meeting_group).new? %>
-  <%= link_to "New Standup Meeting Group", new_standup_meeting_group_path %>
+<%= link_to "New Standup Meeting Group", new_standup_meeting_group_path %>
 <% end %>
 
 <div class="p-2 border-black border-2" id="new_standup_meeting_group">
   <%= render 'form', standup_meeting_group: StandupMeetingGroup.new %>
-
-<div id="standup_meeting_group">
-  <% @standup_meeting_groups.each do |standup_meeting_group| %>
-    <%= render standup_meeting_group %>
-
-    <p>
-      <%= link_to "Show this standup meeting group", standup_meeting_group %>
-    </p>
-  <% end %>
 </div>
-
-<hr class="mb-5 mt-5 border-b-2">
-
-<ul role="list" id="standup_meeting_group_list">
-  <%= render partial: 'standup_meeting_group_list_item', collection: @standup_meeting_groups, as: :standup_meeting_group %>
-</ul>

--- a/app/views/standup_meeting_groups/index.html.erb
+++ b/app/views/standup_meeting_groups/index.html.erb
@@ -1,15 +1,12 @@
 <h1>Standup Meeting Groups</h1>
 
 <% if policy(:standup_meeting_group).new? %>
-<%= link_to "New Standup Meeting Group", new_standup_meeting_group_path %>
+  <div class="p-2 border-black border-2" id="new_standup_meeting_group">
+    <%= render 'form', standup_meeting_group: StandupMeetingGroup.new %>
+  </div>
 <% end %>
 
-<div class="p-2 border-black border-2" id="new_standup_meeting_group">
-  <%= render 'form', standup_meeting_group: StandupMeetingGroup.new %>
-</div>
-
 <hr class="mb-5 mt-5 border-b-2">
-
 
 <ul role="list" id="standup_meeting_group_list">
   <%= render partial: 'standup_meeting_group_list_item', collection: @standup_meeting_groups, as: :standup_meeting_group %>

--- a/spec/policies/standup_meeting_group_policy_spec.rb
+++ b/spec/policies/standup_meeting_group_policy_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe StandupMeetingGroupPolicy, type: :policy do
     create(:standup_meeting_group_user, user:, standup_meeting_group:)
   end
 
-  permissions :create?, :update?, :destroy? do
+  permissions :create?, :update?, :destroy?, :new? do
     it 'denies access if the user is not an admin' do
       expect(subject).not_to permit(user, standup_meeting_group)
     end


### PR DESCRIPTION
### This Pull Request:

- Fixes #111  - Added functionality to the `standup_meeting_groups#index` page to **only** display a link to create a new Standup Meeting Group if the logged in user is an Admin.
- I followed an existing pattern in the app used to hide/display the 'Invite New User' link combining a policy action and a conditional in the view.
- I modified the existing `standup_meeting_group_policy_spec` to include the `:new` action.

### Items to work on:
Can be added to system tests when we implement : )