### PR TITLE
Feedback index

### DIFF
--- a/app/components/feedback/container_component.html.erb
+++ b/app/components/feedback/container_component.html.erb
@@ -1,9 +1,7 @@
 <div class="p-2 border shadow-lg rounded-lg max-w-prose mx-auto flex-1">
   <div class="flex justify-between items-center">
     <%= heading(class: "text-lg") %>
-    <% if Pundit.policy(user, feedback).edit? %>
-      <%= link_to "Edit", edit_feedback_path(feedback), class: 'btn btn-primary btn-sm capitalize' %>
-    <% end %>
+    <%= render Feedback::EditButtonComponent.new(feedback:, current_user: user) %>
   </div>
   <div>
     <% if feedback.completed? %>

--- a/app/components/feedback/edit_button_component.html.erb
+++ b/app/components/feedback/edit_button_component.html.erb
@@ -1,7 +1,0 @@
-<%= link_to(
-  edit_feedback_path(feedback),
-  class: "btn btn-link btn-xs sm:btn-sm capitalize hover:no-underline text-left flex flex-col flex-nowrap gap-y-0.5 items-start",
-) do %>
-  <p>Edit</p>
-  <p>Feedback</p>
-<% end %>

--- a/app/components/feedback/edit_button_component.rb
+++ b/app/components/feedback/edit_button_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Feedback::EditButtonComponent < ViewComponent::Base
-  STYLES = {
+  VARIANTS = {
     button: 'btn-primary',
     link: 'btn-link btn-xs sm:btn-sm hover:no-underline'
   }.freeze
@@ -14,11 +14,11 @@ class Feedback::EditButtonComponent < ViewComponent::Base
   end
 
   def call
-    style_archetype = STYLES.fetch(style)
+    variant = VARIANTS.fetch(style)
 
     link_to(
       edit_feedback_path(feedback),
-      class: "btn btn-sm capitalize #{style_archetype} #{classes}"
+      class: "btn btn-sm capitalize #{variant} #{classes}"
     ) do
       content || 'Edit'
     end

--- a/app/components/feedback/edit_button_component.rb
+++ b/app/components/feedback/edit_button_component.rb
@@ -6,11 +6,11 @@ class Feedback::EditButtonComponent < ViewComponent::Base
     link: 'btn-link btn-xs sm:btn-sm hover:no-underline'
   }.freeze
 
-  def initialize(feedback:, current_user:, style: :button, classes: '')
+  def initialize(feedback:, current_user:, style: :button, class_names: '')
     @feedback = feedback
     @current_user = current_user
     @style = style
-    @classes = classes
+    @class_names = class_names
   end
 
   def call
@@ -18,7 +18,7 @@ class Feedback::EditButtonComponent < ViewComponent::Base
 
     link_to(
       edit_feedback_path(feedback),
-      class: "btn btn-sm capitalize #{variant} #{classes}"
+      class: "btn btn-sm capitalize #{variant} #{class_names}"
     ) do
       content || 'Edit'
     end
@@ -26,7 +26,7 @@ class Feedback::EditButtonComponent < ViewComponent::Base
 
   private
 
-  attr_reader :feedback, :current_user, :style, :classes
+  attr_reader :feedback, :current_user, :style, :class_names
 
   def render?
     feedback.present? && Pundit.policy(current_user, feedback).edit?

--- a/app/components/feedback/edit_button_component.rb
+++ b/app/components/feedback/edit_button_component.rb
@@ -1,14 +1,32 @@
 # frozen_string_literal: true
 
 class Feedback::EditButtonComponent < ViewComponent::Base
-  def initialize(feedback:, current_user:)
+  STYLES = {
+    button: 'btn-primary',
+    link: 'btn-link btn-xs sm:btn-sm hover:no-underline'
+  }.freeze
+
+  def initialize(feedback:, current_user:, style: :button, classes: '')
     @feedback = feedback
     @current_user = current_user
+    @style = style
+    @classes = classes
+  end
+
+  def call
+    style_archetype = STYLES.fetch(style)
+
+    link_to(
+      edit_feedback_path(feedback),
+      class: "btn btn-sm capitalize #{style_archetype} #{classes}"
+    ) do
+      content || 'Edit'
+    end
   end
 
   private
 
-  attr_reader :feedback, :current_user
+  attr_reader :feedback, :current_user, :style, :classes
 
   def render?
     feedback.present? && Pundit.policy(current_user, feedback).edit?

--- a/app/components/feedback/item_component.html.erb
+++ b/app/components/feedback/item_component.html.erb
@@ -3,8 +3,8 @@
     <%= link_to heading_text, feedback_path(feedback), data: { turbo_frame: "_top" } %>
   </h3>
   <div class="flex flex-col gap-2 col-start-1 col-span-2 md:flex-row md:gap-x-6 ">
-    <p><span class="font-bold"><%= partner_label %>: </span><%= feedback.receiver.email %></p>
-    <p><span class="font-bold">Rating: </span><%= feedback.overall_rating %>/10</p>
+    <%= partner_section %>
+    <%= rating_section %>
   </div>
   <div class="flex flex-col gap-2 items-end md:row-start-1 md:row-span-2">
     <p><%= feedback.created_at.to_fs(:slash_format) %></p>

--- a/app/components/feedback/item_component.html.erb
+++ b/app/components/feedback/item_component.html.erb
@@ -1,0 +1,13 @@
+<div class="shadow-lg border rounded-md p-4 grid grid-cols-3 ">
+  <h3 class="text-lg link link-primary text-center mb-2 col-span-3 row-start-1 md:text-left md:col-span-2">
+    <%= link_to heading_text, feedback_path(feedback), data: { turbo_frame: "_top" } %>
+  </h3>
+  <div class="flex flex-col gap-2 col-start-1 col-span-2 md:flex-row md:gap-x-6 ">
+    <p><span class="font-bold"><%= partner_label %>: </span><%= feedback.receiver.email %></p>
+    <p><span class="font-bold">Rating: </span><%= feedback.overall_rating %>/10</p>
+  </div>
+  <div class="flex flex-col gap-2 items-end md:row-start-1 md:row-span-2">
+    <p><%= feedback.created_at.to_fs(:slash_format) %></p>
+    <%= render Feedback::EditButtonComponent.new(feedback:, current_user: user) %>
+  </div>
+</div>

--- a/app/components/feedback/item_component.rb
+++ b/app/components/feedback/item_component.rb
@@ -13,11 +13,37 @@ class Feedback::ItemComponent < ViewComponent::Base
 
   attr_reader :feedback, :user
 
+  def render?
+    Pundit.policy(user, feedback).show?
+  end
+
   def heading_text
     TYPE_HEADINGS.fetch(feedback.referenceable_type)
   end
 
-  def partner_label
-    user == feedback.author ? 'For' : 'From'
+  def partner_section
+    content_tag(:p) do
+      if user == feedback.author
+        render_partner('For: ', feedback.receiver.email)
+      else
+        render_partner('From: ', feedback.author.email)
+      end
+    end
+  end
+
+  def rating_section
+    content_tag(:p) do
+      feedback.completed? ? render_rating : 'Awaiting completion of feedback.'
+    end
+  end
+
+  private
+
+  def render_partner(label, partner)
+    content_tag(:span, label, class: 'font-bold') + partner
+  end
+
+  def render_rating
+    content_tag(:span, 'Rating: ', class: 'font-bold') + "#{feedback.overall_rating}/10"
   end
 end

--- a/app/components/feedback/item_component.rb
+++ b/app/components/feedback/item_component.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Feedback::ItemComponent < ViewComponent::Base
+  TYPE_HEADINGS = {
+    'PairRequest' => 'Pair Programming Feedback',
+    'User' => 'User Feedback'
+  }.freeze
+
+  def initialize(feedback:, current_user:)
+    @feedback = feedback
+    @user = current_user
+  end
+
+  attr_reader :feedback, :user
+
+  def heading_text
+    TYPE_HEADINGS.fetch(feedback.referenceable_type)
+  end
+
+  def partner_label
+    user == feedback.author ? 'For' : 'From'
+  end
+end

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -2,8 +2,8 @@ class FeedbacksController < ApplicationController
   before_action :set_feedback, only: %i[show edit update]
 
   def index
-    @given_feedback = current_user.authored_feedbacks
-    @received_feedback = current_user.received_feedbacks
+    @given_feedback = current_user.authored_feedbacks.order_newest_first
+    @received_feedback = current_user.received_feedbacks.order_newest_first
   end
 
   def show

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -2,8 +2,8 @@ class FeedbacksController < ApplicationController
   before_action :set_feedback, only: %i[show edit update]
 
   def index
-    filter = params[:filter] == 'received' ? :received_feedbacks : :authored_feedbacks
-    @feedback = current_user.public_send(filter)
+    @given_feedback = current_user.authored_feedbacks
+    @received_feedback = current_user.received_feedbacks
   end
 
   def show

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,13 +1,14 @@
 class FeedbacksController < ApplicationController
   before_action :set_feedback, only: %i[show edit update]
 
-  def index; end
+  def index
+    filter = params[:filter] == 'received' ? :received_feedbacks : :authored_feedbacks
+    @feedback = current_user.public_send(filter)
+  end
 
   def show
     authorize @feedback
   end
-
-  def new; end
 
   def edit
     authorize @feedback

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -37,6 +37,8 @@ class Feedback < ApplicationRecord
 
   validates :overall_rating, inclusion: { in: 0..100, message: 'must be in range 0-10' }
 
+  scope :order_newest_first, -> { order(created_at: :desc) }
+
   # rubocop:disable Layout/LineLength
   DATA_OBJECT = {
     feedback: [

--- a/app/policies/feedback_policy.rb
+++ b/app/policies/feedback_policy.rb
@@ -1,12 +1,8 @@
 class FeedbackPolicy < ApplicationPolicy
   alias_method :feedback, :record
 
-  def index?
-    user_is_owner? || user.admin?
-  end
-
   def show?
-    user_is_owner? || user.admin?
+    user == feedback.author || (user == feedback.receiver && feedback.completed?)
   end
 
   def update?

--- a/app/views/feedbacks/index.html.erb
+++ b/app/views/feedbacks/index.html.erb
@@ -1,31 +1,33 @@
-<h1 class="font-bold text-3xl text-center">My Feedback</h1>
+<h1 class="font-bold text-3xl text-center mb-4">My Feedback</h1>
 
-<div class="max-w-4xl mx-auto" data-controller="tabs" data-tabs-active-tab="tab-active">
-  <ul class="tabs">
-    <%= link_to(
-      'Given',
-      "#",
-      data: { tabs_target: "tab", action: "click->tabs#change" },
-      class: "tab tab-lifted",
-    ) %>
-    <%= link_to(
-      'Received',
-      "#",
-      data: { tabs_target: "tab", action: "click->tabs#change" },
-      class: "tab tab-lifted",
-    ) %>
-    <span class="grow border-b border-base-300 rounded-md"></span>  
-  </ul>
+<div class="px-2">
+  <div class="max-w-4xl mx-auto" data-controller="tabs" data-tabs-active-tab="tab-active">
+    <ul class="tabs">
+      <%= link_to(
+        'Given',
+        "#",
+        data: { tabs_target: "tab", action: "click->tabs#change" },
+        class: "tab tab-lifted",
+      ) %>
+      <%= link_to(
+        'Received',
+        "#",
+        data: { tabs_target: "tab", action: "click->tabs#change" },
+        class: "tab tab-lifted",
+      ) %>
+      <span class="grow border-b border-base-300 rounded-md"></span>  
+    </ul>
 
-  <div class="flex flex-col gap-4 p-4 border border-t-0 rounded-b-md" data-tabs-target="panel">
-    <% @given_feedback.each do |item| %>
-      <%= render Feedback::ItemComponent.new(feedback: item, current_user:) %>
-    <% end %>
-  </div>
+    <div class="flex flex-col gap-4 p-4 border border-t-0 rounded-b-md" data-tabs-target="panel">
+      <% @given_feedback.each do |item| %>
+        <%= render Feedback::ItemComponent.new(feedback: item, current_user:) %>
+      <% end %>
+    </div>
 
-  <div class="flex flex-col gap-4 p-4 border border-t-0 rounded-b-md" data-tabs-target="panel">
-    <% @received_feedback.each do |item| %>
-      <%= render Feedback::ItemComponent.new(feedback: item, current_user:) %>
-    <% end %>
+    <div class="flex flex-col gap-4 p-4 border border-t-0 rounded-b-md" data-tabs-target="panel">
+      <% @received_feedback.each do |item| %>
+        <%= render Feedback::ItemComponent.new(feedback: item, current_user:) %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/feedbacks/index.html.erb
+++ b/app/views/feedbacks/index.html.erb
@@ -1,4 +1,27 @@
-<div>
-  <h1 class="font-bold text-4xl">Feedbacks#index</h1>
-  <p>Find me in app/views/feedbacks/index.html.erb</p>
-</div>
+<h1 class="font-bold text-3xl text-center">My Feedback</h1>
+
+<%=  turbo_frame_tag "feedback" do %>
+  <div class="max-w-4xl mx-auto">
+    <div class="tabs">
+      <%= link_to(
+        'Given',
+        feedbacks_path(filter: 'given'),
+        data: { turbo_action: 'advance' },
+        class: "tab tab-lifted #{'tab-active' if params[:filter] == 'given' || params[:filter].nil?}",
+      ) %>
+      <%= link_to(
+        'Received',
+        feedbacks_path(filter: 'received'),
+        data: { turbo_action: 'advance' },
+        class: "tab tab-lifted #{'tab-active' if params[:filter] == 'received'}",
+      ) %>
+      <span class="grow border-b border-base-300 rounded-md"></span>  
+    </div>
+
+    <div class="flex flex-col gap-4 p-4 border border-t-0 rounded-b-md">
+      <% @feedback.each do |item| %>
+        <%= render Feedback::ItemComponent.new(feedback: item, current_user:) %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/feedbacks/index.html.erb
+++ b/app/views/feedbacks/index.html.erb
@@ -1,27 +1,31 @@
 <h1 class="font-bold text-3xl text-center">My Feedback</h1>
 
-<%=  turbo_frame_tag "feedback" do %>
-  <div class="max-w-4xl mx-auto">
-    <div class="tabs">
-      <%= link_to(
-        'Given',
-        feedbacks_path(filter: 'given'),
-        data: { turbo_action: 'advance' },
-        class: "tab tab-lifted #{'tab-active' if params[:filter] == 'given' || params[:filter].nil?}",
-      ) %>
-      <%= link_to(
-        'Received',
-        feedbacks_path(filter: 'received'),
-        data: { turbo_action: 'advance' },
-        class: "tab tab-lifted #{'tab-active' if params[:filter] == 'received'}",
-      ) %>
-      <span class="grow border-b border-base-300 rounded-md"></span>  
-    </div>
+<div class="max-w-4xl mx-auto" data-controller="tabs" data-tabs-active-tab="tab-active">
+  <ul class="tabs">
+    <%= link_to(
+      'Given',
+      "#",
+      data: { tabs_target: "tab", action: "click->tabs#change" },
+      class: "tab tab-lifted",
+    ) %>
+    <%= link_to(
+      'Received',
+      "#",
+      data: { tabs_target: "tab", action: "click->tabs#change" },
+      class: "tab tab-lifted",
+    ) %>
+    <span class="grow border-b border-base-300 rounded-md"></span>  
+  </ul>
 
-    <div class="flex flex-col gap-4 p-4 border border-t-0 rounded-b-md">
-      <% @feedback.each do |item| %>
-        <%= render Feedback::ItemComponent.new(feedback: item, current_user:) %>
-      <% end %>
-    </div>
+  <div class="flex flex-col gap-4 p-4 border border-t-0 rounded-b-md" data-tabs-target="panel">
+    <% @given_feedback.each do |item| %>
+      <%= render Feedback::ItemComponent.new(feedback: item, current_user:) %>
+    <% end %>
   </div>
-<% end %>
+
+  <div class="flex flex-col gap-4 p-4 border border-t-0 rounded-b-md" data-tabs-target="panel">
+    <% @received_feedback.each do |item| %>
+      <%= render Feedback::ItemComponent.new(feedback: item, current_user:) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -16,6 +16,9 @@
           <%= link_to 'Pair Requests', pair_requests_path %>
         </li>
         <li>
+          <%= link_to 'Feedback', feedbacks_path %>
+        </li>
+        <li>
           <%= link_to 'Standup Meeting Groups', standup_meeting_groups_path %>
         </li>
         <% if policy(:invitation).new? %>
@@ -51,6 +54,9 @@
           </li>
           <li>
             <%= link_to 'Pair Requests', pair_requests_path %>
+          </li>
+          <li>
+            <%= link_to 'Feedback', feedbacks_path %>
           </li>
           <% if policy(:invitation).new? %>
             <li>

--- a/app/views/pair_requests/_table_row.html.erb
+++ b/app/views/pair_requests/_table_row.html.erb
@@ -17,7 +17,7 @@
       feedback: pair_request.authored_feedback_for(current_user),
       current_user:,
       style: :link,
-      classes: "text-left flex flex-col flex-nowrap gap-y-0.5 items-start"
+      class_names: "text-left flex flex-col flex-nowrap gap-y-0.5 items-start"
     ) do %>
       <%= content_tag(:p, 'Edit') + content_tag(:p, 'Feedback') %>
     <% end %>

--- a/app/views/pair_requests/_table_row.html.erb
+++ b/app/views/pair_requests/_table_row.html.erb
@@ -15,7 +15,11 @@
     <%= render PairRequest::StatusButtonsComponent.new(pair_request:, current_user:, style: :link) %>
     <%= render Feedback::EditButtonComponent.new(
       feedback: pair_request.authored_feedback_for(current_user),
-      current_user:
-    ) %>
+      current_user:,
+      style: :link,
+      classes: "text-left flex flex-col flex-nowrap gap-y-0.5 items-start"
+    ) do %>
+      <%= content_tag(:p, 'Edit') + content_tag(:p, 'Feedback') %>
+    <% end %>
   <% end %>
 </div>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,2 +1,3 @@
 Time::DATE_FORMATS[:month_day_year] = '%B %-e, %Y'
 Time::DATE_FORMATS[:hour_min_period] = '%-l:%M%P'
+Time::DATE_FORMATS[:slash_format] = '%-m/%-d/%Y'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => '/sidekiq'
   end
 
-  resources :feedbacks, only: %i[edit update show]
+  resources :feedbacks, only: %i[index edit update show]
 
   devise_for :users, skip: [:registrations], controllers: { invitations: 'invitations' }
   as :user do

--- a/spec/components/feedback/edit_button_component_spec.rb
+++ b/spec/components/feedback/edit_button_component_spec.rb
@@ -11,7 +11,15 @@ RSpec.describe Feedback::EditButtonComponent, type: :component do
     it 'renders an edit link' do
       render_inline(described_class.new(feedback: editable_feedback, current_user:))
 
-      expect(page).to have_content('Edit')
+      expect(page).to have_link('Edit')
+    end
+  end
+
+  context 'when the feedback is passed a link style' do
+    it 'renders an edit link with a link styling' do
+      render_inline(described_class.new(feedback: editable_feedback, current_user:, style: :link))
+
+      expect(page).to have_link('Edit', class: 'btn-link')
     end
   end
 

--- a/spec/components/feedback/item_component_spec.rb
+++ b/spec/components/feedback/item_component_spec.rb
@@ -6,32 +6,46 @@ RSpec.describe Feedback::ItemComponent, type: :component do
   let(:user) { create(:user) }
 
   context 'when the user is the author' do
-    let(:feedback) { create(:feedback, author: user) }
+    let(:draft_feedback) { create(:feedback, author: user) }
+    let(:complete_feedback) { create(:feedback, author: user, status: :completed) }
 
     it "renders with the text 'For'" do
-      render_inline(described_class.new(feedback:, current_user: user))
+      render_inline(described_class.new(feedback: draft_feedback, current_user: user))
 
       expect(page).to have_content('For')
     end
 
     it 'renders an edit link' do
-      render_inline(described_class.new(feedback:, current_user: user))
+      render_inline(described_class.new(feedback: draft_feedback, current_user: user))
 
       expect(page).to have_link('Edit')
+    end
+
+    it "renders 'Awaiting completion' with incomplete feedback" do
+      render_inline(described_class.new(feedback: draft_feedback, current_user: user))
+
+      expect(page).to have_content('Awaiting completion')
     end
   end
 
   context 'when the user is the receiver' do
-    let(:feedback) { create(:feedback, receiver: user) }
+    let(:draft_feedback) { create(:feedback, receiver: user) }
+    let(:complete_feedback) { create(:feedback, receiver: user, status: :completed) }
 
-    it "renders with the text 'From'" do
-      render_inline(described_class.new(feedback:, current_user: user))
+    it 'renders nothing with a draft feedback' do
+      render_inline(described_class.new(feedback: draft_feedback, current_user: user))
+
+      expect(page).not_to have_selector('body')
+    end
+
+    it "renders with the text 'From' with completed feedback" do
+      render_inline(described_class.new(feedback: complete_feedback, current_user: user))
 
       expect(page).to have_content('From')
     end
 
-    it 'does not render an edit link' do
-      render_inline(described_class.new(feedback:, current_user: user))
+    it 'does not render an edit link with completed feedback' do
+      render_inline(described_class.new(feedback: complete_feedback, current_user: user))
 
       expect(page).not_to have_button('Edit')
     end

--- a/spec/components/feedback/item_component_spec.rb
+++ b/spec/components/feedback/item_component_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Feedback::ItemComponent, type: :component do
+  let(:user) { create(:user) }
+
+  context 'when the user is the author' do
+    let(:feedback) { create(:feedback, author: user) }
+
+    it "renders with the text 'For'" do
+      render_inline(described_class.new(feedback:, current_user: user))
+
+      expect(page).to have_content('For')
+    end
+
+    it 'renders an edit link' do
+      render_inline(described_class.new(feedback:, current_user: user))
+
+      expect(page).to have_link('Edit')
+    end
+  end
+
+  context 'when the user is the receiver' do
+    let(:feedback) { create(:feedback, receiver: user) }
+
+    it "renders with the text 'From'" do
+      render_inline(described_class.new(feedback:, current_user: user))
+
+      expect(page).to have_content('From')
+    end
+
+    it 'does not render an edit link' do
+      render_inline(described_class.new(feedback:, current_user: user))
+
+      expect(page).not_to have_button('Edit')
+    end
+  end
+
+  context 'when the feedback references a Pair Request' do
+    let(:feedback) { create(:feedback, referenceable: create(:pair_request), author: user) }
+
+    it "renders a 'Pair Programming Feedback' heading" do
+      render_inline(described_class.new(feedback:, current_user: user))
+
+      expect(page).to have_content('Pair Programming Feedback')
+    end
+  end
+
+  context 'when the feedback references a User' do
+    let(:feedback) { create(:feedback, referenceable: create(:user), author: user) }
+
+    it "renders a 'User Feedback' heading" do
+      render_inline(described_class.new(feedback:, current_user: user))
+
+      expect(page).to have_content('User Feedback')
+    end
+  end
+end

--- a/spec/policies/feedback_policy_spec.rb
+++ b/spec/policies/feedback_policy_spec.rb
@@ -9,9 +9,10 @@ RSpec.describe FeedbackPolicy do
   let(:not_owned_feedback) { build(:feedback) }
   let(:authored_feedback) { build(:feedback, author: user, locked_at:) }
   let(:received_feedback) { build(:feedback, receiver: user) }
+  let(:received_complete_feedback) { build(:feedback, receiver: user, status: :completed) }
   let(:locked_at) { nil }
 
-  permissions :index?, :show? do
+  permissions :show? do
     it 'denies access if the user is not an owner of the request' do
       expect(subject).not_to permit(user, not_owned_feedback)
     end
@@ -20,12 +21,12 @@ RSpec.describe FeedbackPolicy do
       expect(subject).to permit(user, authored_feedback)
     end
 
-    it 'grants access when the user is the receiver' do
-      expect(subject).to permit(user, received_feedback)
+    it 'grants access when the user is the receiver on a completed feedback' do
+      expect(subject).to permit(user, received_complete_feedback)
     end
 
-    it 'grants access when the user is an admin' do
-      expect(subject).to permit(admin, not_owned_feedback)
+    it 'denies access when the user is the receiver on a draft feedback' do
+      expect(subject).not_to permit(user, received_feedback)
     end
   end
 


### PR DESCRIPTION
## Issue
Closes #125 

## Description
- Update feedback's `show?` policy to not authorize draft feedback for receivers
- Small refactor for `Feedback::EditButtonComponent` to allow it to fit more usecases.
- Create `Feedback::ItemComponent` to represent an individual feedback "item" in the list of feedback on a user's index page
- Set up route and controller action for `feedbacks#index`
- Add link to feedback index page in navbar
- Create and style the feedback index page using a tab layout - Stimulus Tab Component used for managing the tab behavior

## Screenshots
#### Mobile
![Selection_191](https://github.com/agency-of-learning/PairApp/assets/88392688/b7a11751-72e5-4a18-842b-25cf0b175268)

#### Desktop
![Selection_193](https://github.com/agency-of-learning/PairApp/assets/88392688/55bfbf4a-9a41-4f8a-89bc-5f9cf832e8b8)
