### PR TITLE
add index page for standup meetings

### DIFF
--- a/app/controllers/standup_meetings_controller.rb
+++ b/app/controllers/standup_meetings_controller.rb
@@ -1,7 +1,9 @@
 class StandupMeetingsController < ApplicationController
   def index
     @meeting_date = params[:date].nil? ? Date.current : Date.parse(params[:date])
-    @standup_meeting_group = StandupMeetingGroup.find(params[:standup_meeting_group_id])
+    @standup_meeting_group = StandupMeetingGroup.includes(:users)
+                                                .find(params[:standup_meeting_group_id])
+    authorize @standup_meeting_group, policy_class: StandupMeetingPolicy
     @standup_meetings = @standup_meeting_group.standup_meetings
                                               .includes(:user)
                                               .where(meeting_date: @meeting_date)

--- a/app/controllers/standup_meetings_controller.rb
+++ b/app/controllers/standup_meetings_controller.rb
@@ -1,7 +1,27 @@
 class StandupMeetingsController < ApplicationController
+  # rubocop:disable Metrics/AbcSize
+  def index
+    @meeting_date = params[:date].nil? ? Date.current : Date.parse(params[:date])
+    @standup_meetings = StandupMeeting.includes(:user, :standup_meeting_group)
+                                      .where(
+                                        meeting_date: @meeting_date,
+                                        standup_meeting_group_id: params[:standup_meeting_group_id]
+                                      )
+    @date_options = StandupMeeting.meeting_dates(params[:standup_meeting_group_id])
+    if @standup_meetings.empty?
+      flash[:alert] = 'There are no standups for the date you selected'
+      redirect_to standup_meeting_group_standup_meetings_path(params[:standup_meeting_group_id],
+        date: @date_options.max)
+    else
+      @completed_meetings = @standup_meetings.filter(&:completed?)
+      @current_user_standup_meeting = @standup_meetings.find { |meet| meet.user == current_user }
+      @standup_meeting_group = @standup_meetings.first.standup_meeting_group
+    end
+  end
+  # rubocop:enable Metrics/AbcSize
+
   def edit
-    @standup_meeting = StandupMeeting.includes(:standup_meeting_group)
-                                     .find(params[:id])
+    @standup_meeting = StandupMeeting.includes(:standup_meeting_group).find(params[:id])
     @standup_meeting_group = @standup_meeting.standup_meeting_group
     authorize @standup_meeting
   end

--- a/app/controllers/standup_meetings_controller.rb
+++ b/app/controllers/standup_meetings_controller.rb
@@ -13,8 +13,6 @@ class StandupMeetingsController < ApplicationController
       redirect_to standup_meeting_group_standup_meetings_path(params[:standup_meeting_group_id],
         date: @date_options.max)
     else
-      @completed_meetings = @standup_meetings.filter(&:completed?)
-      @current_user_standup_meeting = @standup_meetings.find { |meet| meet.user == current_user }
       @standup_meeting_group = @standup_meetings.first.standup_meeting_group
     end
   end

--- a/app/controllers/standup_meetings_controller.rb
+++ b/app/controllers/standup_meetings_controller.rb
@@ -1,19 +1,10 @@
 class StandupMeetingsController < ApplicationController
   def index
     @meeting_date = params[:date].nil? ? Date.current : Date.parse(params[:date])
-    @standup_meetings = StandupMeeting.includes(:user, :standup_meeting_group)
-                                      .where(
-                                        meeting_date: @meeting_date,
-                                        standup_meeting_group_id: params[:standup_meeting_group_id]
-                                      )
-    @date_options = StandupMeeting.meeting_dates(params[:standup_meeting_group_id])
-    if @standup_meetings.empty?
-      flash[:alert] = 'There are no standups for the date you selected'
-      redirect_to standup_meeting_group_standup_meetings_path(params[:standup_meeting_group_id],
-        date: @date_options.max)
-    else
-      @standup_meeting_group = @standup_meetings.first.standup_meeting_group
-    end
+    @standup_meeting_group = StandupMeetingGroup.find(params[:standup_meeting_group_id])
+    @standup_meetings = @standup_meeting_group.standup_meetings
+                                              .includes(:user)
+                                              .where(meeting_date: @meeting_date)
   end
 
   def edit

--- a/app/controllers/standup_meetings_controller.rb
+++ b/app/controllers/standup_meetings_controller.rb
@@ -1,5 +1,4 @@
 class StandupMeetingsController < ApplicationController
-  # rubocop:disable Metrics/AbcSize
   def index
     @meeting_date = params[:date].nil? ? Date.current : Date.parse(params[:date])
     @standup_meetings = StandupMeeting.includes(:user, :standup_meeting_group)
@@ -16,7 +15,6 @@ class StandupMeetingsController < ApplicationController
       @standup_meeting_group = @standup_meetings.first.standup_meeting_group
     end
   end
-  # rubocop:enable Metrics/AbcSize
 
   def edit
     @standup_meeting = StandupMeeting.includes(:standup_meeting_group).find(params[:id])

--- a/app/models/standup_meeting.rb
+++ b/app/models/standup_meeting.rb
@@ -37,10 +37,4 @@ class StandupMeeting < ApplicationRecord
   }
 
   scope :for_member, ->(user, group) { where(user:, standup_meeting_group: group) }
-  scope :meeting_dates, ->(group_id) do
-    select(:meeting_date)
-      .where(standup_meeting_group_id: group_id)
-      .distinct
-      .pluck(:meeting_date)
-  end
 end

--- a/app/models/standup_meeting.rb
+++ b/app/models/standup_meeting.rb
@@ -37,4 +37,10 @@ class StandupMeeting < ApplicationRecord
   }
 
   scope :for_member, ->(user, group) { where(user:, standup_meeting_group: group) }
+  scope :meeting_dates, ->(group_id) do
+    select(:meeting_date)
+      .where(standup_meeting_group_id: group_id)
+      .distinct
+      .pluck(:meeting_date)
+  end
 end

--- a/app/policies/standup_meeting_policy.rb
+++ b/app/policies/standup_meeting_policy.rb
@@ -14,6 +14,6 @@ class StandupMeetingPolicy < ApplicationPolicy
   end
 
   def group_member?
-    record.users.where(id: user.id).present?
+    record.users.find_by(id: user.id).present?
   end
 end

--- a/app/policies/standup_meeting_policy.rb
+++ b/app/policies/standup_meeting_policy.rb
@@ -1,8 +1,6 @@
 class StandupMeetingPolicy < ApplicationPolicy
-  alias_method :standup_meeting, :record
-
   def index?
-    user.admin? || matching_user?
+    group_member? || user.admin?
   end
 
   def update?
@@ -12,12 +10,10 @@ class StandupMeetingPolicy < ApplicationPolicy
   private
 
   def matching_user?
-    standup_meeting.user_id == user.id
+    record.user_id == user.id
   end
 
-  class Scope < Scope
-    def resolve
-      user.standup_meetings
-    end
+  def group_member?
+    record.users.where(id: user.id).present?
   end
 end

--- a/app/policies/standup_meeting_policy.rb
+++ b/app/policies/standup_meeting_policy.rb
@@ -14,6 +14,6 @@ class StandupMeetingPolicy < ApplicationPolicy
   end
 
   def group_member?
-    record.users.find_by(id: user.id).present?
+    record.users.exists?(user.id)
   end
 end

--- a/app/views/standup_meetings/index.html.erb
+++ b/app/views/standup_meetings/index.html.erb
@@ -1,0 +1,12 @@
+<div class="max-w-6xl mx-auto p-4">
+  <div class="text-sm breadcrumbs max-w-xs">
+    <ul>
+      <li><%= link_to "Standup Groups", standup_meeting_groups_path %></li> 
+      <li><%= link_to @standup_meeting_group.name, standup_meeting_group_path(@standup_meeting_group) %></li> 
+      <li><%= @meeting_date %></li>
+    </ul>
+  </div>
+  <div class="py-4 flex flex-col md:flex-row justify-between">
+    <h1 class="text-3xl font-bold text-center md:text-left">Standup - <%= @meeting_date %></h1>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
       resources :joins, only: %i[create destroy]
     end
 
-    resources :standup_meetings, only: %i[edit update] do
+    resources :standup_meetings, only: %i[index edit update] do
       scope module: :standup_meetings do
         resources :skips, only: :create
         resources :completions, only: :create

--- a/spec/policies/standup_meeting_policy_spec.rb
+++ b/spec/policies/standup_meeting_policy_spec.rb
@@ -15,16 +15,16 @@ RSpec.describe StandupMeetingPolicy, type: :policy do
   end
 
   permissions :index? do
-    it 'denies access if user is not owner' do
-      expect(subject).not_to permit(random_user, user_standup_meeting)
+    it 'denies access if user is a member of the group' do
+      expect(subject).not_to permit(random_user, standup_meeting_group)
     end
 
     it 'grants access if user is owner' do
-      expect(subject).to permit(user, user_standup_meeting)
+      expect(subject).to permit(user, standup_meeting_group)
     end
 
     it 'grants access if the user is an admin' do
-      expect(subject).to permit(admin, StandupMeeting)
+      expect(subject).to permit(admin, standup_meeting_group)
     end
   end
 


### PR DESCRIPTION
Creates general #index page and shell for other features to be added to the StandupMeeting#index page.


<img width="1728" alt="Screen Shot 2023-07-09 at 6 42 37 PM" src="https://github.com/agency-of-learning/PairApp/assets/2447409/31d5914c-3add-416d-bf7d-ad8e34c07fd6">
