### PR TITLE
Feedback edit

### DIFF
--- a/app/components/feedback/container_component.html.erb
+++ b/app/components/feedback/container_component.html.erb
@@ -1,16 +1,18 @@
 <div class="p-2 border shadow-lg rounded-lg max-w-prose mx-auto flex-1">
-  <div class="flex justify-between items-center">
-    <%= heading(class: "text-lg") %>
-    <%= render Feedback::EditButtonComponent.new(feedback:, current_user: user) %>
-  </div>
-  <div>
-    <% if feedback.completed? %>
-      <div class="p-2">
-        <p><span class="font-bold">Rating:</span> <%= feedback.overall_rating %>/10</p>
-      </div>
-      <%= render Feedback::QuestionComponent.with_collection(questions) %>
-    <% else %>
-      <p class="p-4">Awaiting completion of feedback.</p>
-    <% end %>
-  </div>
+  <%= tag.turbo_frame(id: dom_id(feedback)) do %>
+    <div class="flex justify-between items-center">
+      <%= heading(class: "text-lg") %>
+      <%= render Feedback::EditButtonComponent.new(feedback:, current_user: user) %>
+    </div>
+    <div>
+      <% if feedback.completed? %>
+        <div class="p-2">
+          <p><span class="font-bold">Rating:</span> <%= feedback.overall_rating %>/5</p>
+        </div>
+        <%= render Feedback::QuestionComponent.with_collection(questions) %>
+      <% else %>
+        <p class="p-4">Awaiting completion of feedback.</p>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/app/components/feedback/edit_button_component.rb
+++ b/app/components/feedback/edit_button_component.rb
@@ -6,11 +6,12 @@ class Feedback::EditButtonComponent < ViewComponent::Base
     link: 'btn-link btn-xs sm:btn-sm hover:no-underline'
   }.freeze
 
-  def initialize(feedback:, current_user:, style: :button, class_names: '')
+  def initialize(feedback:, current_user:, style: :button, class_names: '', data: {})
     @feedback = feedback
     @current_user = current_user
     @style = style
     @class_names = class_names
+    @data = data
   end
 
   def call
@@ -18,7 +19,8 @@ class Feedback::EditButtonComponent < ViewComponent::Base
 
     link_to(
       edit_feedback_path(feedback),
-      class: "btn btn-sm capitalize #{variant} #{class_names}"
+      class: "btn btn-sm capitalize #{variant} #{class_names}",
+      data:
     ) do
       content || 'Edit'
     end
@@ -26,7 +28,7 @@ class Feedback::EditButtonComponent < ViewComponent::Base
 
   private
 
-  attr_reader :feedback, :current_user, :style, :class_names
+  attr_reader :feedback, :current_user, :style, :class_names, :data
 
   def render?
     feedback.present? && Pundit.policy(current_user, feedback).edit?

--- a/app/components/feedback/item_component.rb
+++ b/app/components/feedback/item_component.rb
@@ -44,6 +44,6 @@ class Feedback::ItemComponent < ViewComponent::Base
   end
 
   def render_rating
-    content_tag(:span, 'Rating: ', class: 'font-bold') + "#{feedback.overall_rating}/10"
+    content_tag(:span, 'Rating: ', class: 'font-bold') + "#{feedback.overall_rating}/5"
   end
 end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -3,6 +3,7 @@ import '@hotwired/turbo-rails';
 
 const application = Application.start();
 import { Alert, Autosave, Dropdown, Modal, Tabs, Popover, Toggle, Slideover } from "tailwindcss-stimulus-components"
+import TextareaAutogrow from 'stimulus-textarea-autogrow';
 
 application.register('alert', Alert);
 application.register('autosave', Autosave);
@@ -13,6 +14,7 @@ application.register('popover', Popover);
 application.register('toggle', Toggle);
 application.register('slideover', Slideover);
 
+application.register('textarea-autogrow', TextareaAutogrow);
 
 // Configure Stimulus development experience;
 application.debug = true;

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -75,7 +75,7 @@ class Feedback < ApplicationRecord
   # rubocop:enable Layout/LineLength
 
   def overall_rating
-    super / 10
+    super / 20
   end
 
   def update_with_json_answers(params)
@@ -86,7 +86,7 @@ class Feedback < ApplicationRecord
     end
 
     self.data = { feedback: merged_answers }
-    self.overall_rating = (params.dig(:feedback, :overall_rating).to_i * 10) || 0
+    self.overall_rating = (params.dig(:feedback, :overall_rating).to_i * 20) || 0
     self.locked_at ||= 7.days.from_now
     self.status = :completed
     save

--- a/app/views/feedbacks/edit.html.erb
+++ b/app/views/feedbacks/edit.html.erb
@@ -5,7 +5,7 @@
   <%= form_with model: @feedback, local: true, html: { class: 'max-w-prose mx-auto px-4' } do |form| %>
     <p class="font-bold mb-2">Rating:</p>
     <div class="flex gap-x-2 mb-4">
-      <% 11.times do |n| %>
+      <% (1..5).each do |n| %>
         <div class="flex flex-col text-center">
           <%= form.radio_button :overall_rating, n, class: "radio radio-primary" %>
           <%= form.label :overall_rating, n %>

--- a/app/views/feedbacks/edit.html.erb
+++ b/app/views/feedbacks/edit.html.erb
@@ -1,33 +1,33 @@
+<h1 class="text-2xl font-bold mb-4 text-center">Edit Feedback</h1>
 
-<%= form_with model: @feedback, local: true, html: { class: 'max-w-prose mx-auto px-4' } do |form| %>
-  <% if @feedback.errors.any? %>
+<%= turbo_frame_tag @feedback do %>
 
-    <div class="mb-4">
-      <h2 class="text-red-700 text-lg">
-        Please fix <%= pluralize(@feedback.errors.count, "error") %>
-      </h2>
+  <%= form_with model: @feedback, local: true, html: { class: 'max-w-prose mx-auto px-4' } do |form| %>
+    <p class="font-bold mb-2">Rating:</p>
+    <div class="flex gap-x-2 mb-4">
+      <% 11.times do |n| %>
+        <div class="flex flex-col text-center">
+          <%= form.radio_button :overall_rating, n, class: "radio radio-primary" %>
+          <%= form.label :overall_rating, n %>
+        </div>
+      <% end %>
+    </div>
 
-      <ul>
-        <% @feedback.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
+    <% @feedback.data['feedback'].each_with_index do |object, index| %>
+      <div class="form-control mb-4">
+        <%= form.label "data[feedback][#{index}][answer]", object['question'], class: "font-bold mb-2" %>
+        <%= form.text_area "data[feedback][#{index}][answer]",
+          value: object['answer'],
+          required: object['required'],
+          class: "textarea textarea-bordered",
+          data: { controller: 'textarea-autogrow'},
+          rows: '1'
+        %>
+      </div>
+    <% end %>
+
+    <div class="form-control">
+      <%= form.submit "Update Feedback", class: "btn btn-primary btn-wide mx-auto" %>
     </div>
   <% end %>
-
-  <div>
-    <%= form.label "overall_rating", class: "label label-text text-lg " %>
-    <%= form.number_field :overall_rating, class: "input input-bordered input-sm", min: 0, max: 10 %>
-  </div>
-
-  <% @feedback.data['feedback'].each_with_index do |object, index| %>
-    <div class="form-control mb-4">
-      <%= form.label "data[feedback][#{index}][answer]", object['question'], class: "label label-text text-lg" %>
-      <%= form.text_area "data[feedback][#{index}][answer]", value: object['answer'], required: object['required'], class: "textarea textarea-bordered" %>
-    </div>
-  <% end %>
-
-  <div class="form-control">
-    <%= form.submit "Update Feedback", class: "btn btn-primary btn-wide mx-auto" %>
-  </div>
 <% end %>

--- a/app/views/feedbacks/edit.html.erb
+++ b/app/views/feedbacks/edit.html.erb
@@ -1,5 +1,10 @@
 <h1 class="text-2xl font-bold mb-4 text-center">Edit Feedback</h1>
 
+<dl class="text-center mb-2">
+  <dl class="font-bold">For</dl>
+  <dt><%= @feedback.receiver.email %></dt>
+</dl>
+
 <%= turbo_frame_tag @feedback, target: "_top" do %>
 
   <%= form_with model: @feedback, local: true, html: { class: 'max-w-prose mx-auto px-4' } do |form| %>

--- a/app/views/feedbacks/edit.html.erb
+++ b/app/views/feedbacks/edit.html.erb
@@ -1,6 +1,6 @@
 <h1 class="text-2xl font-bold mb-4 text-center">Edit Feedback</h1>
 
-<%= turbo_frame_tag @feedback do %>
+<%= turbo_frame_tag @feedback, target: "_top" do %>
 
   <%= form_with model: @feedback, local: true, html: { class: 'max-w-prose mx-auto px-4' } do |form| %>
     <p class="font-bold mb-2">Rating:</p>

--- a/app/views/pair_requests/_table_row.html.erb
+++ b/app/views/pair_requests/_table_row.html.erb
@@ -17,7 +17,8 @@
       feedback: pair_request.authored_feedback_for(current_user),
       current_user:,
       style: :link,
-      class_names: "text-left flex flex-col flex-nowrap gap-y-0.5 items-start"
+      class_names: "text-left flex flex-col flex-nowrap gap-y-0.5 items-start",
+      data: { turbo_frame: "_top" }
     ) do %>
       <%= content_tag(:p, 'Edit') + content_tag(:p, 'Feedback') %>
     <% end %>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "esbuild": "^0.17.19",
     "flatpickr": "^4.6.13",
     "stimulus-flatpickr": "^3.0.0-0",
+    "stimulus-textarea-autogrow": "^4.1.0",
     "tailwindcss-stimulus-components": "^3.0.4"
   },
   "scripts": {

--- a/spec/components/feedback/container_component_spec.rb
+++ b/spec/components/feedback/container_component_spec.rb
@@ -55,11 +55,11 @@ RSpec.describe Feedback::ContainerComponent, type: :component do
   context 'when the feedback is completed' do
     let(:status) { :completed }
 
-    it 'renders the feedback rating out of 10' do
+    it 'renders the feedback rating out of 5' do
       render_inline(described_class.new(feedback: authored_feedback, current_user:))
 
       expected_rating = authored_feedback.overall_rating
-      expect(page).to have_content("#{expected_rating}/10")
+      expect(page).to have_content("#{expected_rating}/5")
     end
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -705,6 +705,11 @@ stimulus-flatpickr@^3.0.0-0:
   dependencies:
     "@hotwired/stimulus" "^3.0.0"
 
+stimulus-textarea-autogrow@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus-textarea-autogrow/-/stimulus-textarea-autogrow-4.1.0.tgz#faa2f7952062c4508b1566478dc203af7f24f632"
+  integrity sha512-hYz+xN3VZiO+eLl+zok4yvhH+mW5WkvOJEExyVP3J97dWQzc/qPDFdAM1EDJvfUIuRzJVq/WJynqqQwiied5iw==
+
 sucrase@^3.32.0:
   version "3.32.0"
   resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.32.0.tgz#c4a95e0f1e18b6847127258a75cf360bc568d4a7"


### PR DESCRIPTION
## Description
- Add turbo behavior for views with the `Feedback::ContainerComponent` such that it can be replaced by the edit view (and vice versa)
- Add `data` params for the `Feedback::EditButtonComponent` so that turbo can be disabled depending on the situation
- Change feedback ratings to work on a scale of 1-5
    - Note that this shouldn't impact existing data because it's always stored in the database at 0-100. I just changed how this value is displayed and how it's written to the database on form submission.
- Style the edit form
- Add textarea-autogrow stimulus component

## Screenshots
#### Desktop for Full Page Edit
![Selection_207](https://github.com/agency-of-learning/PairApp/assets/88392688/a01d11a4-b001-4427-ad03-f2ffdf6fcfe6)

#### Desktop for Edit Turbo Frame
![Selection_209](https://github.com/agency-of-learning/PairApp/assets/88392688/1d99b429-2da0-47b7-8ce7-156b50fcfb65)

#### Mobile for Full Page Edit
![Selection_212](https://github.com/agency-of-learning/PairApp/assets/88392688/7d28be70-7b48-4d67-8d5e-31770a93a9a4)

#### Mobile for Edit Turbo Frame
![Selection_210](https://github.com/agency-of-learning/PairApp/assets/88392688/92148114-4d6d-4e8a-b009-233be50d3b4f)


## Issue
Closes #140 