### PR TITLE
User names in UI

### DIFF
--- a/app/components/feedback/item_component.rb
+++ b/app/components/feedback/item_component.rb
@@ -24,9 +24,9 @@ class Feedback::ItemComponent < ViewComponent::Base
   def partner_section
     content_tag(:p) do
       if user == feedback.author
-        render_partner('For: ', feedback.receiver.email)
+        render_partner('For: ', feedback.receiver.full_name)
       else
-        render_partner('From: ', feedback.author.email)
+        render_partner('From: ', feedback.author.full_name)
       end
     end
   end

--- a/app/components/pair_request/show_component.html.erb
+++ b/app/components/pair_request/show_component.html.erb
@@ -5,7 +5,7 @@
     <div class="flex flex-col justify-center items-center gap-y-6 lg:flex-row lg:justify-between lg:shadow-lg lg:border lg:rounded-md lg:py-2 lg:px-4">
       <div class="grid grid-cols-2 gap-y-4 items-center lg:flex">
         <div class="even:font-bold lg:even:mr-12 lg:odd:mr-6">Partner</div>
-        <div class="even:font-bold lg:even:mr-12 lg:odd:mr-6"><%= pair_request.partner_for(user).email %></div>
+        <div class="even:font-bold lg:even:mr-12 lg:odd:mr-6"><%= pair_request.partner_for(user).full_name %></div>
         <div class="even:font-bold lg:even:mr-12 lg:odd:mr-6">When</div>
         <div class="even:font-bold lg:even:mr-12 lg:odd:mr-6"><%= format_request_date(pair_request) %></div>
         <div class="even:font-bold lg:even:mr-12 lg:odd:mr-6">Duration</div>

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,8 +70,6 @@ class User < ApplicationRecord
   validates :first_name, presence: true
   validates :last_name, presence: true
 
-  scope :invitee_select_for, ->(user) { User.excluding(user).pluck(:email, :id) }
-
   def self.invite!(attributes = {}, invited_by = nil, options = {}, &)
     default_name = { first_name: 'First', last_name: 'Last' }
     super(attributes.merge(default_name), invited_by, options, &)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,6 +85,10 @@ class User < ApplicationRecord
     authored_feedbacks.or(received_feedbacks)
   end
 
+  def full_name
+    "#{first_name} #{last_name}"
+  end
+
   enum role: {
     member: 0,
     admin: 1

--- a/app/views/feedbacks/edit.html.erb
+++ b/app/views/feedbacks/edit.html.erb
@@ -2,7 +2,7 @@
 
 <dl class="text-center mb-2">
   <dl class="font-bold">For</dl>
-  <dt><%= @feedback.receiver.email %></dt>
+  <dt><%= @feedback.receiver.full_name %></dt>
 </dl>
 
 <%= turbo_frame_tag @feedback, target: "_top" do %>

--- a/app/views/pair_requests/_form.html.erb
+++ b/app/views/pair_requests/_form.html.erb
@@ -3,7 +3,7 @@
     <div id="form-container" class='flex flex-col space-y-4 xl:space-y-0 xl:max-w-full xl:inline-flex xl:justify-around xl:space-x-8 xl:flex-row'>
       <div class="flex justify-between space-x-4 align-middle">
         <%= form.label :invitee_id, class: "label label-text" %>
-        <%= form.collection_select :invitee_id, User.without(current_user), :id, :full_name, {}, { class: 'select select-primary' } %>
+        <%= form.collection_select :invitee_id, User.excluding(current_user), :id, :full_name, {}, { class: 'select select-primary' } %>
       </div>
 
       <div class="flex justify-between space-x-4 align-middle">

--- a/app/views/pair_requests/_form.html.erb
+++ b/app/views/pair_requests/_form.html.erb
@@ -3,10 +3,7 @@
     <div id="form-container" class='flex flex-col space-y-4 xl:space-y-0 xl:max-w-full xl:inline-flex xl:justify-around xl:space-x-8 xl:flex-row'>
       <div class="flex justify-between space-x-4 align-middle">
         <%= form.label :invitee_id, class: "label label-text" %>
-        <%= form.select :invitee_id, 
-                        User.invitee_select_for(current_user), 
-                        {}, 
-                        { class: 'select select-primary' } %>
+        <%= form.collection_select :invitee_id, User.all, :id, :full_name, {}, { class: 'select select-primary' } %>
       </div>
 
       <div class="flex justify-between space-x-4 align-middle">

--- a/app/views/pair_requests/_form.html.erb
+++ b/app/views/pair_requests/_form.html.erb
@@ -3,7 +3,7 @@
     <div id="form-container" class='flex flex-col space-y-4 xl:space-y-0 xl:max-w-full xl:inline-flex xl:justify-around xl:space-x-8 xl:flex-row'>
       <div class="flex justify-between space-x-4 align-middle">
         <%= form.label :invitee_id, class: "label label-text" %>
-        <%= form.collection_select :invitee_id, User.all, :id, :full_name, {}, { class: 'select select-primary' } %>
+        <%= form.collection_select :invitee_id, User.without(current_user), :id, :full_name, {}, { class: 'select select-primary' } %>
       </div>
 
       <div class="flex justify-between space-x-4 align-middle">

--- a/app/views/pair_requests/_pair_request.html.erb
+++ b/app/views/pair_requests/_pair_request.html.erb
@@ -1,11 +1,11 @@
 <div id="<%= dom_id pair_request %>">
   <p>
     <strong>Author:</strong>
-    <%= pair_request.author.email %>
+    <%= pair_request.author.full_name %>
   </p>
 
   <p>
-    <strong>Invitee: <%= pair_request.invitee.email %></strong>
+    <strong>Invitee: <%= pair_request.invitee.full_name %></strong>
   </p>
 
   <p>

--- a/app/views/pair_requests/_table_row.html.erb
+++ b/app/views/pair_requests/_table_row.html.erb
@@ -1,6 +1,8 @@
 <div class="table-row odd:bg-white even:bg-neutral-100 hover:bg-neutral-200 divide-x-2 divide-black">
   <%= render TableCellComponent.new(container_link: pair_request) do %>
-    <%= pair_request.partner_for(current_user).email %>
+    <% partner = pair_request.partner_for(current_user) %>
+    <p><%= partner.first_name %></p>
+    <p><%= partner.last_name %></p>
   <% end %>
 
   <%= render TableCellComponent.new(container_link: pair_request) do %>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -83,4 +83,13 @@ RSpec.describe User do
       expect(user.my_pair_requests).to be_a ActiveRecord::Relation
     end
   end
+
+  describe '#full_name' do
+    let(:user) { create(:user, first_name: 'Albert', last_name: 'Einstein') }
+
+    it "returns the user's first and last name together in a string" do
+      expected_full_name = 'Albert Einstein'
+      expect(user.full_name).to eq(expected_full_name)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -34,70 +34,53 @@
 require 'rails_helper'
 
 RSpec.describe User do
-  describe 'scopes' do
-    describe '.invitee_select_for' do
-      let!(:param_user) { create(:user) }
-      let!(:other_user) { create(:user) }
+  describe '#my_pair_requests' do
+    let!(:user) { create(:user) }
+    let!(:authored_request) { create(:pair_request, author: user) }
+    let!(:received_request) { create(:pair_request, invitee: user) }
 
-      it 'excludes the user in the param' do
-        param_user_data = [param_user.email, param_user.id]
-        expect(described_class.invitee_select_for(param_user)).not_to include(param_user_data)
-      end
-
-      it 'includes other users' do
-        other_user_data = [other_user.email, other_user.id]
-        expect(described_class.invitee_select_for(param_user)).to include(other_user_data)
-      end
+    it "fetches a user's received and authored pair requests" do
+      expect(user.my_pair_requests).to include(authored_request, received_request)
     end
 
-    describe '#my_pair_requests' do
-      let!(:user) { create(:user) }
-      let!(:authored_request) { create(:pair_request, author: user) }
-      let!(:received_request) { create(:pair_request, invitee: user) }
-
-      it "fetches a user's received and authored pair requests" do
-        expect(user.my_pair_requests).to include(authored_request, received_request)
-      end
-
-      it "doesn't fetch other users' requests" do
-        other_request = create(:pair_request)
-        expect(user.my_pair_requests).not_to include(other_request)
-      end
-
-      it 'returns an ActiveRecord Relation' do
-        expect(user.my_pair_requests).to be_a ActiveRecord::Relation
-      end
+    it "doesn't fetch other users' requests" do
+      other_request = create(:pair_request)
+      expect(user.my_pair_requests).not_to include(other_request)
     end
 
-    describe '#role' do
-      let(:user) { build(:user) }
+    it 'returns an ActiveRecord Relation' do
+      expect(user.my_pair_requests).to be_a ActiveRecord::Relation
+    end
+  end
 
-      it 'defaults to member' do
-        expect(user.role).to eq('member')
-      end
+  describe '#role' do
+    let(:user) { build(:user) }
 
-      it 'responds to member? properly' do
-        expect(user.member?).to be(true)
-      end
+    it 'defaults to member' do
+      expect(user.role).to eq('member')
     end
 
-    describe '#my_feedback' do
-      let(:user) { create(:user) }
-      let!(:authored_feedback) { create(:feedback, author: user) }
-      let!(:received_feedback) { create(:feedback, receiver: user) }
+    it 'responds to member? properly' do
+      expect(user.member?).to be(true)
+    end
+  end
 
-      it "fetches a user's received and authored feedback" do
-        expect(user.my_feedback).to include(authored_feedback, received_feedback)
-      end
+  describe '#my_feedback' do
+    let(:user) { create(:user) }
+    let!(:authored_feedback) { create(:feedback, author: user) }
+    let!(:received_feedback) { create(:feedback, receiver: user) }
 
-      it "doesn't return other users' feedback" do
-        other_feedback = create(:feedback)
-        expect(user.my_feedback).not_to include(other_feedback)
-      end
+    it "fetches a user's received and authored feedback" do
+      expect(user.my_feedback).to include(authored_feedback, received_feedback)
+    end
 
-      it 'returns an ActiveRecord Relation' do
-        expect(user.my_pair_requests).to be_a ActiveRecord::Relation
-      end
+    it "doesn't return other users' feedback" do
+      other_feedback = create(:feedback)
+      expect(user.my_feedback).not_to include(other_feedback)
+    end
+
+    it 'returns an ActiveRecord Relation' do
+      expect(user.my_pair_requests).to be_a ActiveRecord::Relation
     end
   end
 end


### PR DESCRIPTION
##  Description
- Display user names instead of user emails throughout the UI (ie for creating and reading pair requests and feedback)

## Screenshots
![Selection_213](https://github.com/agency-of-learning/PairApp/assets/88392688/755197fc-f9c9-48fa-8032-0cfcda3cc3be)

## Issue
Closes #142 