### PR TITLE
Small fix for user styling

### DIFF
--- a/app/components/standup_meeting/meeting_column_component.html.erb
+++ b/app/components/standup_meeting/meeting_column_component.html.erb
@@ -3,7 +3,7 @@
   <div class="collapse-title text-xl font-medium bg-primary text-primary-content h-16">
     <%= title %>
   </div>
-  <div class="collapse-content overflow-scroll"> 
+  <div class="collapse-content overflow-scroll break-all"> 
     <%= content %>
   </div>
 </div>

--- a/app/components/standup_meeting/meeting_row_component.html.erb
+++ b/app/components/standup_meeting/meeting_row_component.html.erb
@@ -1,22 +1,24 @@
 <div class="collapse collapse-arrow border-l border-r border-b space-y-2">
   <input type="checkbox" class="peer" checked />
   <div class="collapse-title text-xl font-medium bg-primary text-primary-content">
-    <%= standup_meeting.user.email %>
+    <%= standup_meeting.user.full_name %>
   </div>
   <div class="collapse-content text-neutral">
     <div class="flex flex-col md:flex-row justify-around space-y-4 md:space-y-0 md:space-x-4 w-full pt-2">
       <div class="flex flex-col w-full md:w-1/3">
         <span class="text-center font-bold">Yesterday</span>
-        <%= standup_meeting.yesterday_work_description %>
+        <p class="break-all"><%= standup_meeting.yesterday_work_description %></p>
       </div>
       <div class="flex flex-col w-full md:w-1/3">
         <span class="text-center font-bold">Today</span>
-        <%= standup_meeting.today_work_description %>
+        <p class="break-all"><%= standup_meeting.today_work_description %></p>
       </div>
-      <div class="flex flex-col w-full md:w-1/3">
-        <span class="text-center font-bold">Blockers</span>
-        <%= standup_meeting.blockers_description %>
-      </div>
+      <% if standup_meeting.blockers_description.present? %>
+        <div class="flex flex-col w-full md:w-1/3">
+          <span class="text-center font-bold">Blockers</span>
+          <p class="break-all"><%= standup_meeting.blockers_description %></p>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/components/standup_meeting/meeting_row_component.html.erb
+++ b/app/components/standup_meeting/meeting_row_component.html.erb
@@ -5,15 +5,15 @@
   </div>
   <div class="collapse-content text-neutral">
     <div class="flex flex-col md:flex-row justify-around space-y-4 md:space-y-0 md:space-x-4 w-full pt-2">
-      <div class="flex flex-col w-1/3">
+      <div class="flex flex-col w-full md:w-1/3">
         <span class="text-center font-bold">Yesterday</span>
         <%= standup_meeting.yesterday_work_description %>
       </div>
-      <div class="flex flex-col w-1/3">
+      <div class="flex flex-col w-full md:w-1/3">
         <span class="text-center font-bold">Today</span>
         <%= standup_meeting.today_work_description %>
       </div>
-      <div class="flex flex-col w-1/3">
+      <div class="flex flex-col w-full md:w-1/3">
         <span class="text-center font-bold">Blockers</span>
         <%= standup_meeting.blockers_description %>
       </div>

--- a/app/components/standup_meeting/meeting_update_component.html.erb
+++ b/app/components/standup_meeting/meeting_update_component.html.erb
@@ -1,6 +1,8 @@
-<div class="border p-4 flex flex-col lg:flex-row justify-between mt-4">
-  <span class="flex flex-col justify-center mr-4 font-bold"><%= user.email %></span>
-  <span class="grow">
-    <%= standup_meeting.public_send(content_type) %>
-  </span>
-</div>
+<% if standup_meeting.public_send(content_type).present? %>
+  <div class="border p-4 flex flex-col lg:flex-row justify-between mt-4">
+    <span class="flex flex-col justify-center mr-4 font-bold"><%= user.email %></span>
+    <span class="grow">
+      <%= standup_meeting.public_send(content_type) %>
+    </span>
+  </div>
+<% end %>


### PR DESCRIPTION
There were some weird styling issues that I noticed when the standup meeting was on mobile:
- column width was 1/3 for users (see before screenshot)
- really long words would overflow the container
- there would be an entry for users in the blockers category, even if there were no users

All 3 of those issues are remedied by this PR.

### screenshots:
**Before**
<img width="318" alt="Screen Shot 2023-07-12 at 2 22 00 PM" src="https://github.com/agency-of-learning/PairApp/assets/2447409/7c6b0216-e3be-4547-aa9a-440f0bd4b34d">

**After**
<img width="319" alt="Screen Shot 2023-07-12 at 2 29 30 PM" src="https://github.com/agency-of-learning/PairApp/assets/2447409/377b8992-7b54-4986-8926-917183847271">
<img width="322" alt="Screen Shot 2023-07-12 at 2 29 21 PM" src="https://github.com/agency-of-learning/PairApp/assets/2447409/aec64b95-e719-414c-8c24-37dd00acce70">

