### PR TITLE
2 bug fixes, improve quality of seeded data

### DIFF
--- a/app/components/standup_meeting/meeting_column_component.html.erb
+++ b/app/components/standup_meeting/meeting_column_component.html.erb
@@ -3,7 +3,7 @@
   <div class="collapse-title text-xl font-medium bg-primary text-primary-content h-16">
     <%= title %>
   </div>
-  <div class="collapse-content overflow-scroll break-all"> 
+  <div class="collapse-content overflow-scroll break-words"> 
     <%= content %>
   </div>
 </div>

--- a/app/components/standup_meeting/meeting_row_component.html.erb
+++ b/app/components/standup_meeting/meeting_row_component.html.erb
@@ -7,16 +7,16 @@
     <div class="flex flex-col md:flex-row justify-around space-y-4 md:space-y-0 md:space-x-4 w-full pt-2">
       <div class="flex flex-col w-full md:w-1/3">
         <span class="text-center font-bold">Yesterday</span>
-        <p class="break-all"><%= standup_meeting.yesterday_work_description %></p>
+        <p class="break-words"><%= standup_meeting.yesterday_work_description %></p>
       </div>
       <div class="flex flex-col w-full md:w-1/3">
         <span class="text-center font-bold">Today</span>
-        <p class="break-all"><%= standup_meeting.today_work_description %></p>
+        <p class="break-words"><%= standup_meeting.today_work_description %></p>
       </div>
       <% if standup_meeting.blockers_description.present? %>
         <div class="flex flex-col w-full md:w-1/3">
           <span class="text-center font-bold">Blockers</span>
-          <p class="break-all"><%= standup_meeting.blockers_description %></p>
+          <p class="break-words"><%= standup_meeting.blockers_description %></p>
         </div>
       <% end %>
     </div>

--- a/app/views/standup_meeting_groups/_table_row.html.erb
+++ b/app/views/standup_meeting_groups/_table_row.html.erb
@@ -2,7 +2,7 @@
     <%= render TableCellComponent.new(
       container_link: standup_meeting_group_standup_meetings_path(
         standup_meeting_group, 
-        date: standup_meeting.meeting_date
+        date: standup_meeting.meeting_date.strftime('%m-%d-%Y')
       )
     ) do %>
       <p><%= standup_meeting.meeting_date %></p>
@@ -11,7 +11,7 @@
   <%= render TableCellComponent.new(
       container_link: standup_meeting_group_standup_meetings_path(
         standup_meeting_group, 
-        date: standup_meeting.meeting_date
+        date: standup_meeting.meeting_date.strftime('%m-%d-%Y')
       )
     ) do %>
     <%= standup_meeting.status %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,11 +1,12 @@
+require 'faker'
 begin
   puts "Seeding users..."
 
   user_data = [
-    { first_name: "First", last_name: "Last", email: "admin@user.com", password: "password", role: "admin" },
-    { first_name: "First", last_name: "Last", email: "user1@user.com", password: "password", role: "member" },
-    { first_name: "First", last_name: "Last", email: "user2@user.com", password: "password", role: "member" },
-    { first_name: "First", last_name: "Last", email: "user3@user.com", password: "password", role: "member" }
+    { first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: "admin@user.com", password: "password", role: "admin" },
+    { first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: "user1@user.com", password: "password", role: "member" },
+    { first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: "user2@user.com", password: "password", role: "member" },
+    { first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: "user3@user.com", password: "password", role: "member" }
   ]
 
   users = []


### PR DESCRIPTION
This PR contains 2 small bug fixes and a quality of life improvement for the seedfile.

## Bug 1
words in the standup meeting updates were being cut in half, rather than being pushed to the next line. Words are now broken to the next line rather than being cut mid-word.

## Bug 2
The date query param in the link on the `StandupMeetingGroup#index` page was incorrectly formatted, which meant that clicking on it would take to the current date no matter what.
This was fixed by changing the format of the date.

## Quality of Life improvement in seed file
When we seed, we use "first" and "last" name as placeholders. Not only does this not look great, but it can be confusing to distinguish whether interfaces are behaving correctly while developing when all the names displayed are the same. To this end, we use the faker gem to create names.