### PR TITLE
fix bug in meeting when checked-in in another group

### DIFF
--- a/app/controllers/standup_meeting_groups_controller.rb
+++ b/app/controllers/standup_meeting_groups_controller.rb
@@ -16,7 +16,10 @@ class StandupMeetingGroupsController < ApplicationController
       items: 10
     )
     @current_user_standup_meeting = current_user.standup_meetings
-                                                .find_by(meeting_date:) || @standup_meetings.new(
+                                                .find_by(
+                                                  meeting_date:,
+                                                  standup_meeting_group: @standup_meeting_group
+                                                ) || @standup_meetings.new(
                                                   user: current_user,
                                                   meeting_date:
                                                 )


### PR DESCRIPTION
Surfaced by Shami -- fixes bug that shows that you've already completed a check in, even though it was in a different group.

Bug was that the find_by didn't also query on the group. This fixes the bug.

To test:
check out branch, boot up server, replant your seeds, and log-in as user. Create a second standup meeting group.
navigate to the show page for one of the groups, and skip the meeting.
Navigate to the show page of the second group. Your check in for the day should not show that you skipped the standup meeting.