### PR TITLE
Split workers from jobs

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,3 +1,3 @@
-class ApplicationJob
-  include Sidekiq::Worker
+class ApplicationJob < ActiveJob::Base
+  queue_as :default
 end

--- a/app/jobs/pair_request/auto_expire_job.rb
+++ b/app/jobs/pair_request/auto_expire_job.rb
@@ -1,0 +1,2 @@
+# TODO: delete this file when all old `PairRequest::AutoExpireJob`s have dequeued
+PairRequest::AutoExpireJob = PairRequest::AutoExpireWorker

--- a/app/workers/application_worker.rb
+++ b/app/workers/application_worker.rb
@@ -1,0 +1,3 @@
+class ApplicationWorker
+  include Sidekiq::Worker
+end

--- a/app/workers/pair_request/auto_expire_worker.rb
+++ b/app/workers/pair_request/auto_expire_worker.rb
@@ -1,5 +1,5 @@
 class PairRequest
-  class AutoExpireJob < ApplicationJob
+  class AutoExpireWorker < ApplicationWorker
     sidekiq_options queue: 'low'
 
     # rubocop:disable Rails/SkipsModelValidations

--- a/app/workers/pair_request/auto_expire_worker.rb
+++ b/app/workers/pair_request/auto_expire_worker.rb
@@ -10,3 +10,6 @@ class PairRequest
     # rubocop:enable Rails/SkipsModelValidations
   end
 end
+
+# TODO: delete this when all old `PairRequest::AutoExpireJob`s have dequeued
+PairRequest::AutoExpireJob = PairRequest::AutoExpireWorker

--- a/app/workers/pair_request/auto_expire_worker.rb
+++ b/app/workers/pair_request/auto_expire_worker.rb
@@ -10,6 +10,3 @@ class PairRequest
     # rubocop:enable Rails/SkipsModelValidations
   end
 end
-
-# TODO: delete this when all old `PairRequest::AutoExpireJob`s have dequeued
-PairRequest::AutoExpireJob = PairRequest::AutoExpireWorker

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,6 @@ module PairApp
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.active_storage.variant_processor = :mini_magick
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -10,5 +10,5 @@ require 'rufus-scheduler'
 s = Rufus::Scheduler.singleton
 
 s.every '30m' do
-  PairRequest::AutoExpireJob.perform_async
+  PairRequest::AutoExpireWorker.perform_async
 end

--- a/spec/workers/pair_request/auto_expire_worker_spec.rb
+++ b/spec/workers/pair_request/auto_expire_worker_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe PairRequest::AutoExpireJob do
+RSpec.describe PairRequest::AutoExpireWorker do
   let!(:expired_pair_request) do
     create(:pair_request, :skip_validation, status: :pending, when: 1.day.ago)
   end


### PR DESCRIPTION
## Description
- Move current jobs (which use sidekiq API) to new `workers/` folder and change their names to use `Worker`
  - This includes a small failsafe to prevent currently enqueued `AutoExpireWorkers` with their `Job` name from failing
- Create new `ApplicationJob` that inherits from `ActiveJob`
- Configure `ActiveJob` to use the sidekiq queue adapter