### PR TITLE
add simplecov for codecoverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ node_modules/
 
 # ignore byebug history
 .byebug_history
+
+# coverage
+/coverage

--- a/Gemfile
+++ b/Gemfile
@@ -45,13 +45,13 @@ group :development do
 end
 
 group :test do
+  gem 'simplecov'
+  gem 'simplecov-cobertura'
   gem 'capybara'
   gem 'faker' # Fake data
   gem 'rspec-sidekiq'
   gem 'selenium-webdriver'
   gem 'webdrivers'
-  gem 'simplecov'
-  gem 'simplecov-cobertura'
 end
 
 gem 'pundit', '~> 2.3'

--- a/Gemfile
+++ b/Gemfile
@@ -45,12 +45,12 @@ group :development do
 end
 
 group :test do
-  gem 'simplecov'
-  gem 'simplecov-cobertura'
   gem 'capybara'
   gem 'faker' # Fake data
   gem 'rspec-sidekiq'
   gem 'selenium-webdriver'
+  gem 'simplecov'
+  gem 'simplecov-cobertura'
   gem 'webdrivers'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ group :test do
   gem 'rspec-sidekiq'
   gem 'selenium-webdriver'
   gem 'webdrivers'
+  gem 'simplecov'
+  gem 'simplecov-cobertura'
 end
 
 gem 'pundit', '~> 2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
       actionmailer (>= 5.0)
       devise (>= 4.6)
     diff-lcs (1.5.0)
+    docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.12.0)
@@ -338,6 +339,15 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.14.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sprockets (4.2.0)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -432,6 +442,8 @@ DEPENDENCIES
   selenium-webdriver
   sendgrid-ruby
   sidekiq
+  simplecov
+  simplecov-cobertura
   sprockets-rails
   stimulus-rails
   tailwindcss-rails (~> 2.0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@
 # the additional setup, and require it from the spec files that actually need
 # it.
 #
-require "simplecov"
+require 'simplecov'
 SimpleCov.start
 
 require 'simplecov-cobertura'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,12 @@
 # the additional setup, and require it from the spec files that actually need
 # it.
 #
+require "simplecov"
+SimpleCov.start
+
+require 'simplecov-cobertura'
+SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'pundit/rspec'
 


### PR DESCRIPTION
To contextualize the comment below:
> In order to produce an accurate coverage comparison, Codecov must have the coverage report for the pull request base.

Since we don't have simple cov in `main`, I wouldn't expect a coverage report in the base. 