### PR TITLE
Profile migration and model

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: profiles
+#
+#  id         :bigint           not null, primary key
+#  bio        :text
+#  job_title  :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_profiles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class Profile < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,6 +72,8 @@ class User < ApplicationRecord
   validates :first_name, presence: true
   validates :last_name, presence: true
 
+  after_create :create_profile!
+
   def self.invite!(attributes = {}, invited_by = nil, options = {}, &)
     default_name = { first_name: 'First', last_name: 'Last' }
     super(attributes.merge(default_name), invited_by, options, &)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,6 +67,8 @@ class User < ApplicationRecord
   has_many :standup_meetings, dependent: :destroy
   has_many :standup_meeting_groups, through: :standup_meeting_groups_users
 
+  has_one :profile, dependent: :destroy
+
   validates :first_name, presence: true
   validates :last_name, presence: true
 

--- a/db/migrate/20230721223136_create_profiles.rb
+++ b/db/migrate/20230721223136_create_profiles.rb
@@ -1,0 +1,11 @@
+class CreateProfiles < ActiveRecord::Migration[7.0]
+  def change
+    create_table :profiles do |t|
+      t.references :user, null: false, foreign_key: true
+      t.text :bio
+      t.string :job_title
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230721231634_backfill_user_profiles.rb
+++ b/db/migrate/20230721231634_backfill_user_profiles.rb
@@ -1,0 +1,10 @@
+class BackfillUserProfiles < ActiveRecord::Migration[7.0]
+  # prevent locking
+  disable_ddl_transaction!
+
+  def up
+    User.find_each do |user|
+      Profile.create!(user:)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_21_223136) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_21_231634) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_21_003955) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_21_223136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_21_003955) do
     t.datetime "updated_at", null: false
     t.index ["author_id"], name: "index_pair_requests_on_author_id"
     t.index ["invitee_id"], name: "index_pair_requests_on_invitee_id"
+  end
+
+  create_table "profiles", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.text "bio"
+    t.string "job_title"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
   create_table "standup_meeting_groups", force: :cascade do |t|
@@ -116,6 +125,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_21_003955) do
   add_foreign_key "feedbacks", "users", column: "receiver_id"
   add_foreign_key "pair_requests", "users", column: "author_id"
   add_foreign_key "pair_requests", "users", column: "invitee_id"
+  add_foreign_key "profiles", "users"
   add_foreign_key "standup_meetings", "standup_meeting_groups"
   add_foreign_key "standup_meetings", "users"
 end

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: profiles
+#
+#  id         :bigint           not null, primary key
+#  bio        :text
+#  job_title  :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_profiles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :profile do
+    user { nil }
+    bio { "MyText" }
+    job_title { "MyString" }
+  end
+end

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -19,8 +19,8 @@
 #
 FactoryBot.define do
   factory :profile do
-    user { nil }
-    bio { "MyText" }
-    job_title { "MyString" }
+    user
+    bio { Faker::Lorem.paragraph }
+    job_title { Faker::Job.title }
   end
 end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -19,6 +19,6 @@
 #
 require 'rails_helper'
 
-RSpec.describe Profile, type: :model do
+RSpec.describe Profile do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: profiles
+#
+#  id         :bigint           not null, primary key
+#  bio        :text
+#  job_title  :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_profiles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe Profile, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## Description
- Add migration for new profile model
- Add association with user with `has_one/belongs_to`
- Add `after_create` callback for creating a profile for new users
- Add backfill migration to create a profile for all currently existing users 

## Other Comments
Didn't add the ActiveStorage stuff yet because there's some other configuration around that (S3 particularly). This should unblock any issue depending on having a profile model to work with except for resume uploads (#179), which will require ActiveStorage.