### PR TITLE
Update the Pair Request Error message

### DIFF
--- a/app/models/pair_request.rb
+++ b/app/models/pair_request.rb
@@ -34,7 +34,7 @@ class PairRequest < ApplicationRecord
   validates :when,
     presence: true,
     inclusion: { in: (Date.current..(Date.current + 1.month)),
-                 message: 'field must not be in the past' }
+                 message: 'field must not be in the past or more than 1 month into the future' }
   validates :duration, presence: true, numericality: { greater_than_or_equal_to: 5.minutes }
   validates :status, presence: true
 


### PR DESCRIPTION
## What's the change? 
Changed the error message to reflect the two possible error cases.
1. When the pair request date is in the past
2. When the pair request date is more than 1 month in the future.

## What key workflows are impacted?
None

## Highlights / Surprises / Risks / Cleanup
This change should be temporary, until a more appropriate fix can be completed.

## Demo / Screenshots
<img width="1272" alt="Screen Shot 2023-07-28 at 2 15 17 AM" src="https://github.com/agency-of-learning/PairApp/assets/134003653/448b94e3-fc8f-4a8a-958c-cc87c14535b9">

## Issue ticket number and link
#192 https://github.com/agency-of-learning/PairApp/issues/192
## Checklist before requesting a review
n/a
