### PR TITLE
fix: Update pair request `when` validation

### DIFF
--- a/app/models/pair_request.rb
+++ b/app/models/pair_request.rb
@@ -34,8 +34,9 @@ class PairRequest < ApplicationRecord
 
   validates :when,
     presence: true,
-    inclusion: { in: (Date.current..(Date.current + 1.month)),
-                 message: 'field must not be in the past or more than 1 month into the future' }
+    inclusion: { in: (Date.current..(Date.current + 0.month)),
+                 message: 'field must not be in the past or more than 1 month into the future' },
+                 if: -> { pending? }
   validates :duration, presence: true, numericality: { greater_than_or_equal_to: 5.minutes }
   validates :status, presence: true
 

--- a/app/models/pair_request.rb
+++ b/app/models/pair_request.rb
@@ -34,7 +34,7 @@ class PairRequest < ApplicationRecord
 
   validates :when,
     presence: true,
-    inclusion: { in: (Date.current..(Date.current + 1.months)),
+    inclusion: { in: (Date.current..(Date.current + 1.month)),
                  message: 'field must not be in the past or more than 1 month into the future' },
     if: -> { pending? }
   validates :duration, presence: true, numericality: { greater_than_or_equal_to: 5.minutes }

--- a/app/models/pair_request.rb
+++ b/app/models/pair_request.rb
@@ -34,9 +34,9 @@ class PairRequest < ApplicationRecord
 
   validates :when,
     presence: true,
-    inclusion: { in: (Date.current..(Date.current + 0.month)),
+    inclusion: { in: (Date.current..(Date.current + 0.months)),
                  message: 'field must not be in the past or more than 1 month into the future' },
-                 if: -> { pending? }
+    if: -> { pending? }
   validates :duration, presence: true, numericality: { greater_than_or_equal_to: 5.minutes }
   validates :status, presence: true
 

--- a/app/models/pair_request.rb
+++ b/app/models/pair_request.rb
@@ -34,7 +34,7 @@ class PairRequest < ApplicationRecord
 
   validates :when,
     presence: true,
-    inclusion: { in: (Date.current..(Date.current + 0.months)),
+    inclusion: { in: (Date.current..(Date.current + 1.months)),
                  message: 'field must not be in the past or more than 1 month into the future' },
     if: -> { pending? }
   validates :duration, presence: true, numericality: { greater_than_or_equal_to: 5.minutes }

--- a/spec/models/pair_request_spec.rb
+++ b/spec/models/pair_request_spec.rb
@@ -131,14 +131,47 @@ RSpec.describe PairRequest do
       expect(subject).to be_valid
     end
 
-    context 'when date is more than a month into the future' do
-      let(:when_date) { Date.current + 2.months }
+    context 'when a request is pending' do
+      context 'when date is more than a month into the future' do
+        let(:when_date) { Date.current + 2.months }
 
-      it 'is invalid' do
-        expect(subject).not_to be_valid
+        it 'is invalid' do
+          expect(subject).not_to be_valid
+        end
+      end
+
+      context 'when date is in the past' do
+        let(:when_date) { Date.current - 2.months }
+
+        it 'is invalid' do
+          expect(subject).not_to be_valid
+        end
+      end
+    end
+
+    context 'when a pair request is not pending' do
+      before do
+        subject.completed!
+      end
+
+      context 'a date 2 months in the future' do
+        let(:when_date) { Date.current + 2.months }
+
+        it 'is valid' do
+          expect(subject).to be_valid
+        end
+      end
+
+      context 'a past date' do
+        let(:when_date) { Date.current - 1.month }
+
+        it 'is valid' do
+          expect(subject).to be_valid
+        end
       end
     end
   end
+
 
   describe '#started?' do
     context "when the request hasn't started" do

--- a/spec/models/pair_request_spec.rb
+++ b/spec/models/pair_request_spec.rb
@@ -149,12 +149,12 @@ RSpec.describe PairRequest do
       end
     end
 
-    context 'when a pair request is not pending' do
+    context 'when a request is not pending' do
       before do
         subject.completed!
       end
 
-      context 'a date 2 months in the future' do
+      context 'with a date 2 months in the future' do
         let(:when_date) { Date.current + 2.months }
 
         it 'is valid' do
@@ -162,7 +162,7 @@ RSpec.describe PairRequest do
         end
       end
 
-      context 'a past date' do
+      context 'with a past date' do
         let(:when_date) { Date.current - 1.month }
 
         it 'is valid' do
@@ -171,7 +171,6 @@ RSpec.describe PairRequest do
       end
     end
   end
-
 
   describe '#started?' do
     context "when the request hasn't started" do


### PR DESCRIPTION
* Added a conditional for the time box validation
* Updated spec to add test cases for new conditional validation

## What's the change?
Adds a conditional to the pair request `when` field validation. The validation only runs when the pair request status is `pending`

## What key workflows are impacted?
Pair request creation

## Checklist before requesting a review

- [x] Ran the linter 😅 
- [x] Did you add appropriate automated tests?


This PR may also impact #201 