### PR TITLE
User mentee application styling

### DIFF
--- a/app/components/user_mentee_application/section_component.html.erb
+++ b/app/components/user_mentee_application/section_component.html.erb
@@ -1,5 +1,5 @@
 <section class='flex flex-col'>
-  <h1 class='font-bold text-2xl text-center mb-3 text-black-300'><%= header_text %></h1>
+  <h1 class='font-bold text-2xl text-left mb-3 text-black-300 sm:text-center'><%= header_text %></h1>
   <%= content %>
 
 <div class="divider my-3"></div>

--- a/app/components/user_mentee_application/section_component.html.erb
+++ b/app/components/user_mentee_application/section_component.html.erb
@@ -1,0 +1,4 @@
+<section class='flex flex-col'>
+  <h1 class='font-bold text-xl text-center'><%= header_text %></h1>
+  <%= content %>
+</section>

--- a/app/components/user_mentee_application/section_component.html.erb
+++ b/app/components/user_mentee_application/section_component.html.erb
@@ -1,4 +1,6 @@
 <section class='flex flex-col'>
-  <h1 class='font-bold text-xl text-center'><%= header_text %></h1>
+  <h1 class='font-bold text-2xl text-center mb-3 text-black-300'><%= header_text %></h1>
   <%= content %>
+
+<div class="divider my-3"></div>
 </section>

--- a/app/components/user_mentee_application/section_component.rb
+++ b/app/components/user_mentee_application/section_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class UserMenteeApplication::SectionComponent < ViewComponent::Base
+  def initialize(header_text:)
+    @header_text = header_text
+  end
+
+  private
+
+  attr_reader :header_text
+end

--- a/app/helpers/user_mentee_applications_helper.rb
+++ b/app/helpers/user_mentee_applications_helper.rb
@@ -1,0 +1,8 @@
+module UserMenteeApplicationsHelper
+  REASONS_FOR_APPLYING = [
+    'Struggling to land my first job as a junior dev',
+    'I want more of a support network as a dev',
+    'Landed my job and want more coaching',
+    'Experienced dev and want to help'
+  ].freeze
+end

--- a/app/models/user_mentee_application.rb
+++ b/app/models/user_mentee_application.rb
@@ -29,6 +29,8 @@
 class UserMenteeApplication < ApplicationRecord
   belongs_to :user
 
+  validates :available_hours_per_week, numericality: { greater_than: 0, less_than_or_equal_to: 60 }
+
   validates :city, :state, :country, :reason_for_applying, :learned_to_code, :project_experience,
     :available_hours_per_week, presence: true
 

--- a/app/models/user_mentee_application.rb
+++ b/app/models/user_mentee_application.rb
@@ -27,8 +27,15 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class UserMenteeApplication < ApplicationRecord
-  belongs_to :user, dependent: :destroy
+  belongs_to :user
 
   validates :city, :state, :country, :reason_for_applying, :learned_to_code, :project_experience,
     :available_hours_per_week, presence: true
+
+  REASONS_FOR_APPLYING = [
+    'Struggling to land my first job as a junior dev',
+    'I want more of a support network as a dev',
+    'Landed my job and want more coaching',
+    'Experienced dev and want to help'
+  ].freeze
 end

--- a/app/models/user_mentee_application.rb
+++ b/app/models/user_mentee_application.rb
@@ -33,11 +33,4 @@ class UserMenteeApplication < ApplicationRecord
 
   validates :city, :state, :country, :reason_for_applying, :learned_to_code, :project_experience,
     :available_hours_per_week, presence: true
-
-  REASONS_FOR_APPLYING = [
-    'Struggling to land my first job as a junior dev',
-    'I want more of a support network as a dev',
-    'Landed my job and want more coaching',
-    'Experienced dev and want to help'
-  ].freeze
 end

--- a/app/views/user_mentee_applications/new.html.erb
+++ b/app/views/user_mentee_applications/new.html.erb
@@ -7,11 +7,11 @@
     <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Tell us about your journey') do %>
       <div class="flex flex-col mb-5">
         <%= form.label :learned_to_code, 'How did you learn to code?', class: 'font-bold' %>
-        <%= form.text_area :learned_to_code, class: 'textarea textarea-bordered', required: true %>
+        <%= form.text_area :learned_to_code, class: 'textarea textarea-bordered', required: true, data: { controller: 'textarea-autogrow' } %>
       </div>
       <div class="flex flex-col">
         <%= form.label :project_experience, "Describe a project you’ve worked on that you especially loved or are proud of.",  class: 'font-bold' %>
-        <%= form.text_area :project_experience, class: 'textarea textarea-bordered', required: true %>
+        <%= form.text_area :project_experience, class: 'textarea textarea-bordered', required: true, data: { controller: 'textarea-autogrow' } %>
       </div>
     <% end %>
 
@@ -71,7 +71,7 @@
     <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Additional Information') do %>
       <div class="flex flex-col">
         <%= form.label :additional_information, 'Anything else we should know?', class: 'font-bold' %>
-        <%= form.text_area :additional_information, class: 'textarea textarea-bordered' %>
+        <%= form.text_area :additional_information, class: 'textarea textarea-bordered', data: { controller: 'textarea-autogrow' } %>
       </div>
     <% end %>
 

--- a/app/views/user_mentee_applications/new.html.erb
+++ b/app/views/user_mentee_applications/new.html.erb
@@ -18,7 +18,7 @@
     <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Tell us about your interest in the Agency of Learning') do %>
       <div class="flex flex-col mb-5">
         <%= form.label :reason_for_applying, 'Why are you here?', class: 'font-bold' %>
-        <%= form.select :reason_for_applying, options_for_select(UserMenteeApplication::REASONS_FOR_APPLYING), class: 'form-input mb-2', required: true %>
+        <%= form.select :reason_for_applying, options_for_select(UserMenteeApplicationsHelper::REASONS_FOR_APPLYING), class: 'form-input mb-2', required: true %>
       </div>
 
       <div class="flex flex-col">

--- a/app/views/user_mentee_applications/new.html.erb
+++ b/app/views/user_mentee_applications/new.html.erb
@@ -7,23 +7,23 @@
     <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Tell us about your journey') do %>
       <div class="flex flex-col mb-5">
         <%= form.label :learned_to_code, 'How did you learn to code?', class: 'font-bold' %>
-        <%= form.text_area :learned_to_code, class: 'form-input border-2 mb-2', required: true %>
+        <%= form.text_area :learned_to_code, class: 'textarea textarea-bordered', required: true %>
       </div>
       <div class="flex flex-col">
         <%= form.label :project_experience, "Describe a project you’ve worked on that you especially loved or are proud of.",  class: 'font-bold' %>
-        <%= form.text_area :project_experience, class: 'form-input border-2 mb-2', required: true %>
+        <%= form.text_area :project_experience, class: 'textarea textarea-bordered', required: true %>
       </div>
     <% end %>
 
     <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Tell us about your interest in the Agency of Learning') do %>
       <div class="flex flex-col mb-5">
         <%= form.label :reason_for_applying, 'Why are you here?', class: 'font-bold' %>
-        <%= form.select :reason_for_applying, options_for_select(UserMenteeApplicationsHelper::REASONS_FOR_APPLYING), class: 'form-input mb-2', required: true %>
+        <%= form.select :reason_for_applying, options_for_select(UserMenteeApplicationsHelper::REASONS_FOR_APPLYING), {}, class: 'select select-bordered', required: true %>
       </div>
 
       <div class="flex flex-col">
         <%= form.label :referral_source, 'How did you hear about The Agency of Learning?', class: 'font-bold' %>
-        <%= form.text_field :referral_source, class: 'form-input border-2 mb-2' %>
+        <%= form.text_field :referral_source, class: 'input input-bordered mb-2' %>
       </div>
 
       <div class="flex flex-col">
@@ -32,7 +32,7 @@
           min: 1,
           max: 60,
           value: @user_mentee_application.available_hours_per_week.presence || 1,
-          class: 'form-input mb-2',
+          class: 'input input-sm input-bordered',
           required: true
         %>
       </div>
@@ -41,29 +41,29 @@
     <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Current Location Information') do %>
       <div class="flex flex-col">
         <%= form.label :city, class: 'font-bold' %>
-        <%= form.text_field :city, class: 'form-input border-2 mb-2', required: true %>
+        <%= form.text_field :city, class: 'input input-bordered mb-2', required: true %>
       </div>
 
       <div class="flex flex-col">
         <%= form.label :state, class: 'font-bold' %>
-        <%= form.text_field :state, class: 'form-input border-2 mb-2', required: true %>
+        <%= form.text_field :state, class: 'input input-bordered mb-2', required: true %>
       </div>
 
       <div class="flex flex-col">
         <%= form.label :country, class: 'font-bold' %>
-        <%= form.text_field :country, class: 'form-input border-2 mb-2', required: true %>
+        <%= form.text_field :country, class: 'input input-bordered mb-2', required: true %>
       </div>
     <% end %>
 
     <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Job Hunting Information') do %>
       <div class="flex flex-col">
         <%= form.label :linkedin_url, class: 'font-bold' %>
-        <%= form.text_field :linkedin_url, class: 'form-input border-2 mb-2' %>
+        <%= form.text_field :linkedin_url, class: 'input input-bordered mb-2' %>
       </div>
 
       <div class="flex flex-col">
         <%= form.label :github_url, class: 'font-bold' %>
-        <%= form.text_field :github_url, class: 'form-input border-2 mb-2' %>
+        <%= form.text_field :github_url, class: 'input input-bordered mb-2' %>
       </div>
       <%# RESUME WILL GO HERE LATER ON%>
     <% end %>
@@ -71,11 +71,11 @@
     <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Additional Information') do %>
       <div class="flex flex-col">
         <%= form.label :additional_information, 'Anything else we should know?', class: 'font-bold' %>
-        <%= form.text_area :additional_information, class: 'form-input border-2 mb-2' %>
+        <%= form.text_area :additional_information, class: 'textarea textarea-bordered' %>
       </div>
     <% end %>
 
-    <%= form.submit "Submit", class: 'btn btn-primary btn-wide mx-auto mt-5' %>
+    <%= form.submit "Submit", class: 'btn btn-primary btn-wide mx-auto mt-5 mb-5' %>
   </div>
 
 

--- a/app/views/user_mentee_applications/new.html.erb
+++ b/app/views/user_mentee_applications/new.html.erb
@@ -1,66 +1,89 @@
-<dl class="text-center mb-2">
-  <dt><%= current_user.full_name %></dt>
-</dl>
+<h1 class="text-center font-bold text-2xl mb-2">
+  Welcome <%= current_user.first_name %>!
+</h1>
 
-<%= form_with model: @user_mentee_application, local: true, html: { class: 'flex flex-col' } do |form| %>
+<%= form_with model: @user_mentee_application, local: true, html: { class: 'max-w-prose mx-auto' } do |form| %>
+  <div class='flex flex-col'>
+    <section class='flex flex-col'>
+      <h1 class='flex font-bold text-xl'>Tell us about your Journey</h1>
+      <div class="flex flex-col">
+        <%= form.label :learned_to_code, 'How did you learn to code?', class: 'font-bold' %>
+        <%= form.text_area :learned_to_code, class: 'form-input border-2' %>
+      </div>
+      <div class="flex flex-col">
+        <%= form.label :project_experience, class: 'font-bold' %>
+        <%= form.text_area :project_experience, class: 'form-input border-2' %>
+      </div>
+    </section>
 
-  <div class="flex flex-col">
-    <%= form.label :city, class: 'font-bold' %>
-    <%= form.text_field :city, class: 'form-input' %>
-  </div>
+    <section class="flex flex-col">
+      <h1 class='flex font-bold text-xl'>Tell us about your interest in the Agency of Learning</h1>
+      <div class="flex flex-col">
+        <%= form.label :reason_for_applying, 'Why are you here?', class: 'font-bold' %>
+        <%= form.select :reason_for_applying, options_for_select(UserMenteeApplication::REASONS_FOR_APPLYING), class: 'form-input' %>
+      </div>
 
-  <div class="flex flex-col">
-    <%= form.label :state, class: 'font-bold' %>
-    <%= form.text_field :state, class: 'form-input' %>
-  </div>
+      <div class="flex flex-col">
+        <%= form.label :referral_source, 'How did you hear about The Agency of Learning?', class: 'font-bold' %>
+        <%= form.text_field :referral_source, class: 'form-input' %>
+      </div>
 
-  <div class="flex flex-col">
-    <%= form.label :country, class: 'font-bold' %>
-    <%= form.text_field :country, class: 'form-input' %>
-  </div>
+      <div class="flex flex-col">
+        <%= form.label :available_hours_per_week, 'How many hours per week are you able to commit to The Agency of Learning?', class: 'font-bold' %>
+        <%= form.number_field :available_hours_per_week,
+          min: 1,
+          max: 60,
+          value: @user_mentee_application.available_hours_per_week.presence || 1,
+          class: 'form-input'
+        %>
+      </div>
+    </section>
 
-  <div class="flex flex-col">
-    <%= form.label :reason_for_applying, class: 'font-bold' %>
-    <%= form.text_area :reason_for_applying, class: 'form-input' %>
-  </div>
+    <section>
+      <h1 class='flex font-bold text-xl'>Current Location Information</h1>
+      <div class="flex flex-col">
+        <%= form.label :city, class: 'font-bold' %>
+        <%= form.text_field :city, class: 'form-input' %>
+      </div>
 
-  <div class="flex flex-col">
-    <%= form.label :linkedin_url, class: 'font-bold' %>
-    <%= form.text_field :linkedin_url, class: 'form-input' %>
-  </div>
+      <div class="flex flex-col">
+        <%= form.label :state, class: 'font-bold' %>
+        <%= form.text_field :state, class: 'form-input' %>
+      </div>
 
-  <div class="flex flex-col">
-    <%= form.label :github_url, class: 'font-bold' %>
-    <%= form.text_field :github_url, class: 'form-input' %>
-  </div>
+      <div class="flex flex-col">
+        <%= form.label :country, class: 'font-bold' %>
+        <%= form.text_field :country, class: 'form-input' %>
+      </div>
+    </section>
 
-  <div class="flex flex-col">
-    <%= form.label :learned_to_code, class: 'font-bold' %>
-    <%= form.text_area :learned_to_code, class: 'form-input' %>
-  </div>
+    <section>
+      <h1 class='flex font-bold text-xl'>Job Hunting Information</h1>
+      <div class="flex flex-col">
+        <%= form.label :linkedin_url, class: 'font-bold' %>
+        <%= form.text_field :linkedin_url, class: 'form-input' %>
+      </div>
 
-  <div class="flex flex-col">
-    <%= form.label :project_experience, class: 'font-bold' %>
-    <%= form.text_area :project_experience, class: 'form-input' %>
-  </div>
+      <div class="flex flex-col">
+        <%= form.label :github_url, class: 'font-bold' %>
+        <%= form.text_field :github_url, class: 'form-input' %>
+      </div>
 
-  <div class="flex flex-col">
-    <%= form.label :available_hours_per_week, class: 'font-bold' %>
-    <%= form.number_field :available_hours_per_week, class: 'form-input' %>
-  </div>
+      <%# RESUME WILL GO HERE LATER ON%>
+    </section>
 
-  <div class="flex flex-col">
-    <%= form.label :referral_source, class: 'font-bold' %>
-    <%= form.text_field :referral_source, class: 'form-input' %>
-  </div>
+    <section>
+      <h1 class='flex font-bold text-xl'>Additional Information</h1>
+      <div class="flex flex-col">
+        <%= form.label :additional_information, 'Anything else we should know?', class: "font-bold" %>
+        <%= form.text_area :additional_information, class: "form-input" %>
+      </div>
+    </section>
 
-  <div class="flex flex-col">
-    <%= form.label :additional_information, class: "font-bold" %>
-    <%= form.text_area :additional_information, class: "form-input" %>
-  </div>
 
-  <div class="flex">
     <%= form.submit "Submit Application", class: "btn btn-primary btn-wide mx-auto" %>
   </div>
+
+
 
 <% end %>

--- a/app/views/user_mentee_applications/new.html.erb
+++ b/app/views/user_mentee_applications/new.html.erb
@@ -4,23 +4,21 @@
 
 <%= form_with model: @user_mentee_application, local: true, html: { class: 'max-w-prose mx-auto' } do |form| %>
   <div class='flex flex-col'>
-    <section class='flex flex-col'>
-      <h1 class='font-bold text-xl text-center'>Tell us about your journey</h1>
+    <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Tell us about your journey') do %>
       <div class="flex flex-col">
         <%= form.label :learned_to_code, 'How did you learn to code?', class: 'font-bold' %>
-        <%= form.text_area :learned_to_code, class: 'form-input border-2' %>
+        <%= form.text_area :learned_to_code, class: 'form-input border-2', required: true %>
       </div>
       <div class="flex flex-col">
         <%= form.label :project_experience, "Describe a project you’ve worked on that you especially loved or are proud of",  class: 'font-bold' %>
-        <%= form.text_area :project_experience, class: 'form-input border-2' %>
+        <%= form.text_area :project_experience, class: 'form-input border-2', required: true %>
       </div>
-    </section>
+    <% end %>
 
-    <section class="flex flex-col">
-      <h1 class='font-bold text-xl text-center'>Tell us about your interest in the Agency of Learning</h1>
+    <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Tell us about your interest in the Agency of Learning') do %>
       <div class="flex flex-col">
         <%= form.label :reason_for_applying, 'Why are you here?', class: 'font-bold' %>
-        <%= form.select :reason_for_applying, options_for_select(UserMenteeApplication::REASONS_FOR_APPLYING), class: 'form-input' %>
+        <%= form.select :reason_for_applying, options_for_select(UserMenteeApplication::REASONS_FOR_APPLYING), class: 'form-input', required: true %>
       </div>
 
       <div class="flex flex-col">
@@ -34,31 +32,30 @@
           min: 1,
           max: 60,
           value: @user_mentee_application.available_hours_per_week.presence || 1,
-          class: 'form-input'
+          class: 'form-input',
+          required: true
         %>
       </div>
-    </section>
+    <% end %>
 
-    <section>
-      <h1 class='font-bold text-xl text-center'>Current Location Information</h1>
+    <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Current Location Information') do %>
       <div class="flex flex-col">
         <%= form.label :city, class: 'font-bold' %>
-        <%= form.text_field :city, class: 'form-input border-2' %>
+        <%= form.text_field :city, class: 'form-input border-2', required: true %>
       </div>
 
       <div class="flex flex-col">
         <%= form.label :state, class: 'font-bold' %>
-        <%= form.text_field :state, class: 'form-input border-2' %>
+        <%= form.text_field :state, class: 'form-input border-2', required: true %>
       </div>
 
       <div class="flex flex-col">
         <%= form.label :country, class: 'font-bold' %>
-        <%= form.text_field :country, class: 'form-input border-2' %>
+        <%= form.text_field :country, class: 'form-input border-2', required: true %>
       </div>
-    </section>
+    <% end %>
 
-    <section>
-      <h1 class='font-bold text-xl text-center'>Job Hunting Information</h1>
+    <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Job Hunting Information') do %>
       <div class="flex flex-col">
         <%= form.label :linkedin_url, class: 'font-bold' %>
         <%= form.text_field :linkedin_url, class: 'form-input border-2' %>
@@ -68,18 +65,15 @@
         <%= form.label :github_url, class: 'font-bold' %>
         <%= form.text_field :github_url, class: 'form-input border-2' %>
       </div>
-
       <%# RESUME WILL GO HERE LATER ON%>
-    </section>
+    <% end %>
 
-    <section>
-      <h1 class='font-bold text-xl text-center'>Additional Information</h1>
+    <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Additional Information') do %>
       <div class="flex flex-col">
         <%= form.label :additional_information, 'Anything else we should know?', class: "font-bold" %>
         <%= form.text_area :additional_information, class: "form-input border-2" %>
       </div>
-    </section>
-
+    <% end %>
 
     <%= form.submit "Submit", class: "btn btn-primary btn-wide mx-auto mt-5" %>
   </div>

--- a/app/views/user_mentee_applications/new.html.erb
+++ b/app/views/user_mentee_applications/new.html.erb
@@ -5,19 +5,19 @@
 <%= form_with model: @user_mentee_application, local: true, html: { class: 'max-w-prose mx-auto' } do |form| %>
   <div class='flex flex-col'>
     <section class='flex flex-col'>
-      <h1 class='flex font-bold text-xl'>Tell us about your Journey</h1>
+      <h1 class='font-bold text-xl text-center'>Tell us about your journey</h1>
       <div class="flex flex-col">
         <%= form.label :learned_to_code, 'How did you learn to code?', class: 'font-bold' %>
         <%= form.text_area :learned_to_code, class: 'form-input border-2' %>
       </div>
       <div class="flex flex-col">
-        <%= form.label :project_experience, class: 'font-bold' %>
+        <%= form.label :project_experience, "Describe a project you’ve worked on that you especially loved or are proud of",  class: 'font-bold' %>
         <%= form.text_area :project_experience, class: 'form-input border-2' %>
       </div>
     </section>
 
     <section class="flex flex-col">
-      <h1 class='flex font-bold text-xl'>Tell us about your interest in the Agency of Learning</h1>
+      <h1 class='font-bold text-xl text-center'>Tell us about your interest in the Agency of Learning</h1>
       <div class="flex flex-col">
         <%= form.label :reason_for_applying, 'Why are you here?', class: 'font-bold' %>
         <%= form.select :reason_for_applying, options_for_select(UserMenteeApplication::REASONS_FOR_APPLYING), class: 'form-input' %>
@@ -25,7 +25,7 @@
 
       <div class="flex flex-col">
         <%= form.label :referral_source, 'How did you hear about The Agency of Learning?', class: 'font-bold' %>
-        <%= form.text_field :referral_source, class: 'form-input' %>
+        <%= form.text_field :referral_source, class: 'form-input border-2' %>
       </div>
 
       <div class="flex flex-col">
@@ -40,48 +40,48 @@
     </section>
 
     <section>
-      <h1 class='flex font-bold text-xl'>Current Location Information</h1>
+      <h1 class='font-bold text-xl text-center'>Current Location Information</h1>
       <div class="flex flex-col">
         <%= form.label :city, class: 'font-bold' %>
-        <%= form.text_field :city, class: 'form-input' %>
+        <%= form.text_field :city, class: 'form-input border-2' %>
       </div>
 
       <div class="flex flex-col">
         <%= form.label :state, class: 'font-bold' %>
-        <%= form.text_field :state, class: 'form-input' %>
+        <%= form.text_field :state, class: 'form-input border-2' %>
       </div>
 
       <div class="flex flex-col">
         <%= form.label :country, class: 'font-bold' %>
-        <%= form.text_field :country, class: 'form-input' %>
+        <%= form.text_field :country, class: 'form-input border-2' %>
       </div>
     </section>
 
     <section>
-      <h1 class='flex font-bold text-xl'>Job Hunting Information</h1>
+      <h1 class='font-bold text-xl text-center'>Job Hunting Information</h1>
       <div class="flex flex-col">
         <%= form.label :linkedin_url, class: 'font-bold' %>
-        <%= form.text_field :linkedin_url, class: 'form-input' %>
+        <%= form.text_field :linkedin_url, class: 'form-input border-2' %>
       </div>
 
       <div class="flex flex-col">
         <%= form.label :github_url, class: 'font-bold' %>
-        <%= form.text_field :github_url, class: 'form-input' %>
+        <%= form.text_field :github_url, class: 'form-input border-2' %>
       </div>
 
       <%# RESUME WILL GO HERE LATER ON%>
     </section>
 
     <section>
-      <h1 class='flex font-bold text-xl'>Additional Information</h1>
+      <h1 class='font-bold text-xl text-center'>Additional Information</h1>
       <div class="flex flex-col">
         <%= form.label :additional_information, 'Anything else we should know?', class: "font-bold" %>
-        <%= form.text_area :additional_information, class: "form-input" %>
+        <%= form.text_area :additional_information, class: "form-input border-2" %>
       </div>
     </section>
 
 
-    <%= form.submit "Submit Application", class: "btn btn-primary btn-wide mx-auto" %>
+    <%= form.submit "Submit", class: "btn btn-primary btn-wide mx-auto mt-5" %>
   </div>
 
 

--- a/app/views/user_mentee_applications/new.html.erb
+++ b/app/views/user_mentee_applications/new.html.erb
@@ -1,29 +1,29 @@
-<h1 class="text-center font-bold text-2xl mb-2">
+<h1 class="text-center font-bold text-3xl mb-5">
   Welcome <%= current_user.first_name %>!
 </h1>
 
 <%= form_with model: @user_mentee_application, local: true, html: { class: 'max-w-prose mx-auto' } do |form| %>
-  <div class='flex flex-col'>
+  <div class='flex flex-col ml-5 mr-5'>
     <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Tell us about your journey') do %>
-      <div class="flex flex-col">
+      <div class="flex flex-col mb-5">
         <%= form.label :learned_to_code, 'How did you learn to code?', class: 'font-bold' %>
-        <%= form.text_area :learned_to_code, class: 'form-input border-2', required: true %>
+        <%= form.text_area :learned_to_code, class: 'form-input border-2 mb-2', required: true %>
       </div>
       <div class="flex flex-col">
-        <%= form.label :project_experience, "Describe a project you’ve worked on that you especially loved or are proud of",  class: 'font-bold' %>
-        <%= form.text_area :project_experience, class: 'form-input border-2', required: true %>
+        <%= form.label :project_experience, "Describe a project you’ve worked on that you especially loved or are proud of.",  class: 'font-bold' %>
+        <%= form.text_area :project_experience, class: 'form-input border-2 mb-2', required: true %>
       </div>
     <% end %>
 
     <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Tell us about your interest in the Agency of Learning') do %>
-      <div class="flex flex-col">
+      <div class="flex flex-col mb-5">
         <%= form.label :reason_for_applying, 'Why are you here?', class: 'font-bold' %>
-        <%= form.select :reason_for_applying, options_for_select(UserMenteeApplication::REASONS_FOR_APPLYING), class: 'form-input', required: true %>
+        <%= form.select :reason_for_applying, options_for_select(UserMenteeApplication::REASONS_FOR_APPLYING), class: 'form-input mb-2', required: true %>
       </div>
 
       <div class="flex flex-col">
         <%= form.label :referral_source, 'How did you hear about The Agency of Learning?', class: 'font-bold' %>
-        <%= form.text_field :referral_source, class: 'form-input border-2' %>
+        <%= form.text_field :referral_source, class: 'form-input border-2 mb-2' %>
       </div>
 
       <div class="flex flex-col">
@@ -32,7 +32,7 @@
           min: 1,
           max: 60,
           value: @user_mentee_application.available_hours_per_week.presence || 1,
-          class: 'form-input',
+          class: 'form-input mb-2',
           required: true
         %>
       </div>
@@ -41,41 +41,41 @@
     <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Current Location Information') do %>
       <div class="flex flex-col">
         <%= form.label :city, class: 'font-bold' %>
-        <%= form.text_field :city, class: 'form-input border-2', required: true %>
+        <%= form.text_field :city, class: 'form-input border-2 mb-2', required: true %>
       </div>
 
       <div class="flex flex-col">
         <%= form.label :state, class: 'font-bold' %>
-        <%= form.text_field :state, class: 'form-input border-2', required: true %>
+        <%= form.text_field :state, class: 'form-input border-2 mb-2', required: true %>
       </div>
 
       <div class="flex flex-col">
         <%= form.label :country, class: 'font-bold' %>
-        <%= form.text_field :country, class: 'form-input border-2', required: true %>
+        <%= form.text_field :country, class: 'form-input border-2 mb-2', required: true %>
       </div>
     <% end %>
 
     <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Job Hunting Information') do %>
       <div class="flex flex-col">
         <%= form.label :linkedin_url, class: 'font-bold' %>
-        <%= form.text_field :linkedin_url, class: 'form-input border-2' %>
+        <%= form.text_field :linkedin_url, class: 'form-input border-2 mb-2' %>
       </div>
 
       <div class="flex flex-col">
         <%= form.label :github_url, class: 'font-bold' %>
-        <%= form.text_field :github_url, class: 'form-input border-2' %>
+        <%= form.text_field :github_url, class: 'form-input border-2 mb-2' %>
       </div>
       <%# RESUME WILL GO HERE LATER ON%>
     <% end %>
 
     <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Additional Information') do %>
       <div class="flex flex-col">
-        <%= form.label :additional_information, 'Anything else we should know?', class: "font-bold" %>
-        <%= form.text_area :additional_information, class: "form-input border-2" %>
+        <%= form.label :additional_information, 'Anything else we should know?', class: 'font-bold' %>
+        <%= form.text_area :additional_information, class: 'form-input border-2 mb-2' %>
       </div>
     <% end %>
 
-    <%= form.submit "Submit", class: "btn btn-primary btn-wide mx-auto mt-5" %>
+    <%= form.submit "Submit", class: 'btn btn-primary btn-wide mx-auto mt-5' %>
   </div>
 
 

--- a/spec/components/user_mentee_application/section_component_spec.rb
+++ b/spec/components/user_mentee_application/section_component_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserMenteeApplication::SectionComponent, type: :component do
+  it 'renders header text for the component' do
+    render_inline(described_class.new(header_text: 'I am awesome!'))
+
+    expect(page).to have_content('I am awesome!')
+  end
+end


### PR DESCRIPTION
## What's the change?
Adds styling for the New Page (User Mentee Application).
Properly organizes the data as per the wireframes.

<img width="399" alt="Screenshot 2023-08-14 at 8 10 47 PM" src="https://github.com/agency-of-learning/PairApp/assets/1283983/6e7e4eb3-b701-40ee-a41b-6eda0912005d">
<img width="1920" alt="Screenshot 2023-08-14 at 8 11 27 PM" src="https://github.com/agency-of-learning/PairApp/assets/1283983/9ec643f1-c4c1-44cc-835a-b7b8ab063bc6">
