### PR TITLE
Add breadcrumbs to standup meeting edit page

### DIFF
--- a/app/views/standup_meetings/edit.html.erb
+++ b/app/views/standup_meetings/edit.html.erb
@@ -1,4 +1,17 @@
 <div class="max-w-4xl mx-auto">
+  <div class="text-sm breadcrumbs px-8">
+    <ul>
+      <li><%= link_to @standup_meeting_group %></li> 
+      <li>
+        <%= link_to(
+          @standup_meeting.meeting_date,
+          standup_meeting_group_standup_meetings_path(@standup_meeting_group, @standup_meeting)
+        ) %>
+      </li>
+      <li>Check-In</li>
+    </ul>
+  </div>
+
   <div class="p-8 flex justify-between ">
     <h1 class="text-3xl font-bold">Get-up, Standup!</h1>
     <%= link_to 'Back', :back, class: 'link text-primary text-lg mt-2' %>

--- a/app/views/standup_meetings/index.html.erb
+++ b/app/views/standup_meetings/index.html.erb
@@ -2,7 +2,7 @@
   <div class="text-sm breadcrumbs md:max-w-lg">
     <ul>
       <li><%= link_to "Standup Groups", standup_meeting_groups_path %></li> 
-      <li><%= link_to @standup_meeting_group.name, standup_meeting_group_path(@standup_meeting_group) %></li> 
+      <li><%= link_to @standup_meeting_group %></li> 
       <li><%= @meeting_date %></li>
     </ul>
   </div>


### PR DESCRIPTION
## What's the change?
- Add breadcrumbs to standup meeting edit page

## What key workflows are impacted?
Navigation on standup meetings edit page

## Highlights / Surprises / Risks / Cleanup
The ticket suggested a trails that would go `Standup Groups > PairApp > 2023-08-20 > Check-In`, but this cannot fit inline on mobile. This leads to horizontal scroll behavior that I think looks/feels bad, so I just chose to ax the top level breadcrumb to standup group index.

In theory, you *could* allow the full trail to show as soon as there's enough screen width to fit the 4th item, but DaisyUI doesn't let you hide items in the breadcrumb list. We'd probably have to roll our own breadcrumb component, and I'm not convinced it's worth the effort.

## Demo / Screenshots
#### Desktop
![image](https://github.com/agency-of-learning/PairApp/assets/88392688/f190b1f7-5cda-40b8-a43a-9a1eab3218f8)

#### Mobile
![image](https://github.com/agency-of-learning/PairApp/assets/88392688/786fcf46-8f6b-49d0-bd72-03a4d4c3fdea)

## Issue ticket number and link
Closes #154 

## Checklist before requesting a review

Please delete items that are not relevant.

- [x] Did you add any relevant tags and decide if this PR is a Draft vs. Ready for Review?
