### PR TITLE
Add support for inline code formatting to trix editor

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -24,6 +24,10 @@
   @apply list-decimal pl-4;
 }
 
+.trix-content code {
+  @apply bg-[#eee] py-1;
+}
+
 trix-toolbar {
   @apply sticky top-0 z-50 bg-white;
 }

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,3 +3,5 @@ import '@hotwired/turbo-rails';
 import './controllers';
 import 'trix';
 import '@rails/actiontext';
+
+import './trix_extensions/inline_code';

--- a/app/javascript/trix_extensions/inline_code.js
+++ b/app/javascript/trix_extensions/inline_code.js
@@ -1,0 +1,38 @@
+import Trix from 'trix';
+
+// fix for inline code formatting
+// https://github.com/basecamp/trix/issues/552#issuecomment-427141510
+Trix.config.textAttributes.inlineCode = {
+  tagName: 'code',
+  inheritable: true,
+};
+
+function getCodeFormattingType(editor) {
+  if (editor.attributeIsActive('code')) return 'block';
+  if (editor.attributeIsActive('inlineCode')) return 'inline';
+
+  const range = editor.getSelectedRange();
+  if (range[0] === range[1]) return 'block';
+
+  const text = editor.getSelectedDocument().toString().trim();
+  return /\n/.test(text) ? 'block' : 'inline';
+}
+
+document.addEventListener('trix-initialize', (event) => {
+  const element = event.target;
+  const { toolbarElement, editor } = element;
+
+  const blockCodeButton = toolbarElement.querySelector('[data-trix-attribute=code]');
+  const inlineCodeButton = blockCodeButton.cloneNode(true);
+
+  inlineCodeButton.hidden = true;
+  inlineCodeButton.dataset.trixAttribute = 'inlineCode';
+  blockCodeButton.insertAdjacentElement('afterend', inlineCodeButton);
+
+  element.addEventListener('trix-selection-change', () => {
+    const type = getCodeFormattingType(editor);
+    blockCodeButton.hidden = type === 'inline';
+    inlineCodeButton.hidden = type === 'block';
+  });
+});
+

--- a/app/javascript/trix_extensions/inline_code.js
+++ b/app/javascript/trix_extensions/inline_code.js
@@ -35,4 +35,3 @@ document.addEventListener('trix-initialize', (event) => {
     inlineCodeButton.hidden = type === 'block';
   });
 });
-


### PR DESCRIPTION
## What's the change?
- Add support for inline code formatting with the trix editor.

Trix doesn't support this out of the box. This change allows the `<>` (code button) to become context sensitive such that if you highlight some text that occurs on one line, it'll be styled inline when you click the `<>` button.

## What key workflows are impacted?
Creating blog posts

## Demo / Screenshots

https://github.com/agency-of-learning/PairApp/assets/88392688/fb6fd0d1-4ef4-4711-bd56-78802ce246c7

## Checklist before requesting a review

Please delete items that are not relevant.

- [x] Related to readability and consistency: Did you add comments and/or documentation? (README, Notion, etc.)
- [x] Did you leave helpful inline PR comments for the reviewer(s)?
- [x] Did you include instructions for how to test in the ticket?
- [x] Did you add any relevant tags and decide if this PR is a Draft vs. Ready for Review?
