### PR TITLE
Fix adding a featured blog post

### DIFF
--- a/app/policies/featured_blog_post_policy.rb
+++ b/app/policies/featured_blog_post_policy.rb
@@ -5,6 +5,10 @@ class FeaturedBlogPostPolicy < ApplicationPolicy
     true
   end
 
+  def create?
+    user.admin?
+  end
+
   def update?
     user.admin?
   end

--- a/spec/policies/featured_blog_post_policy_spec.rb
+++ b/spec/policies/featured_blog_post_policy_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FeaturedBlogPostPolicy, type: :policy do
   let(:admin) { create(:user, :admin) }
   let(:featured_published_post) { build(:featured_blog_post, :with_published_post) }
 
-  permissions :update?, :destroy? do
+  permissions :create?, :update?, :destroy? do
     it 'denies permission for a regular user' do
       expect(subject).not_to permit(user, featured_published_post)
     end


### PR DESCRIPTION
## What's the change?
- Fix bug with feature button

This bug emerged when I changed the policy to create a feature from checking `create?` on a `FeaturedBlogPost` to checking `feature?` on a `BlogPost`. I removed the `#create?` method for the `FeaturedBlogPostPolicy` thinking it was unnecessary, but didn't account for the [controller using it](https://github.com/agency-of-learning/PairApp/blob/main/app/controllers/featured_blog_posts_controller.rb#L9)

## What key workflows are impacted?
Featuring blog posts

## Checklist before requesting a review

Please delete items that are not relevant.

- [x] Did you add appropriate automated tests?
- [x] Did you add any relevant tags and decide if this PR is a Draft vs. Ready for Review?
