### PR TITLE
add open_to_work banner to profile pic

### DIFF
--- a/app/assets/images/open_to_work.svg
+++ b/app/assets/images/open_to_work.svg
@@ -1,0 +1,15 @@
+<svg version="1.1"
+  viewBox='0 0 100 100'
+  xmlns="http://www.w3.org/2000/svg" class='rounded-full'>
+  <linearGradient id="Gradient2" x1="0" x2="0" y1="0" y2="1">
+    <stop offset="0%" stop-color="#38d68e" stop-opacity="0" />
+    <stop offset="50%" stop-color="#38d68e" />
+    <stop offset="90%" stop-color="#38d68e" />
+    <stop offset="100%" stop-color="#38d68e"  stop-opacity="0"/>
+  </linearGradient>
+  <path id="text-path-0" d="M 98.592 238.486 C 82.418 244.562 155.421 453.67 392.959 388.795"></path>
+  <path style="fill: url(#Gradient2)" d="M -0.08 -2.896 L 14.807 15.448 C 14.807 15.448 4.799 61.403 41.578 82.811 C 67.899 98.132 99.889 75.049 99.889 75.049 L 100.034 105.591 L 0.229 105.478 L -0.08 -2.896 Z"></path>
+  <text style="fill: rgb(236, 253, 243); font-family: Arial, sans-serif; font-size: 38px; font-weight: 700; white-space: pre;" transform="matrix(0.271828, 0, 0, 0.271828, -19.355154, -10.013632)">
+    <textPath href="#text-path-0">Open to work</textPath>
+  </text>
+</svg>

--- a/app/components/profile/picture_component.html.erb
+++ b/app/components/profile/picture_component.html.erb
@@ -1,6 +1,10 @@
 <figure class="rounded-full w-64 h-64 mx-auto sm:mx-0 relative border-2 border-black bg-black mb-2">
-  <%= image_tag profile_picture_src, class: 'w-full object-cover rounded-full' %>
-  <%= tag.figcaption(class: "absolute bottom-0 translate-y-1 z-90 py-2 rounded-lg w-full text-center font-bold #{figcaption_colors}") do %>
-    <%= profile.job_search_status.humanize.titleize %>
-  <% end %>
+  <div class="relative inline-block w-full object-cover rounded-full">
+    <%= image_tag profile_picture_src, class: 'h-auto max-w-full block' %>
+    <% if open_to_work? %>
+      <div class="absolute top-0 left-0 w-full object-cover rounded-full">
+        <%= render inline: Rails.root.join('app/assets/images/open_to_work.svg').read %>
+      </div>
+    <% end %>
+  </div>
 </figure>

--- a/app/components/profile/picture_component.html.erb
+++ b/app/components/profile/picture_component.html.erb
@@ -2,7 +2,7 @@
   <div class="relative inline-block w-full object-cover rounded-full">
     <%= image_tag profile_picture_src, class: 'h-auto max-w-full block' %>
     <% if open_to_work? %>
-      <div class="absolute top-0 left-0 w-full object-cover rounded-full">
+      <div class="absolute top-0 left-0 w-full">
         <%= render inline: Rails.root.join('app/assets/images/open_to_work.svg').read %>
       </div>
     <% end %>

--- a/app/components/profile/picture_component.html.erb
+++ b/app/components/profile/picture_component.html.erb
@@ -1,7 +1,7 @@
 <figure class="rounded-full w-64 h-64 mx-auto sm:mx-0 relative border-2 border-black bg-black mb-2">
   <div class="relative inline-block w-full object-cover rounded-full">
     <%= image_tag profile_picture_src, class: 'h-auto max-w-full block' %>
-    <% if open_to_work? %>
+    <% if profile.open_to_work? %>
       <div class="absolute top-0 left-0 w-full">
         <%= render inline: Rails.root.join('app/assets/images/open_to_work.svg').read %>
       </div>

--- a/app/components/profile/picture_component.rb
+++ b/app/components/profile/picture_component.rb
@@ -26,4 +26,8 @@ class Profile::PictureComponent < ViewComponent::Base
       'placeholder_profile_picture.png'
     end
   end
+
+  def open_to_work?
+    profile.job_search_status == 'open_to_work'
+  end
 end

--- a/app/components/profile/picture_component.rb
+++ b/app/components/profile/picture_component.rb
@@ -26,8 +26,4 @@ class Profile::PictureComponent < ViewComponent::Base
       'placeholder_profile_picture.png'
     end
   end
-
-  def open_to_work?
-    profile.job_search_status == 'open_to_work'
-  end
 end

--- a/spec/components/profile/picture_component_spec.rb
+++ b/spec/components/profile/picture_component_spec.rb
@@ -23,35 +23,4 @@ RSpec.describe Profile::PictureComponent, type: :component do
       expect(page).to have_css("img[src*='#{attachment_filename}']")
     end
   end
-
-  context 'when the profile indicates the user is not job searching' do
-    it 'renders the caption with red colors' do
-      render_inline(described_class.new(profile:))
-
-      figcaption = page.find('figcaption')
-      expect(figcaption[:class]).to include('red')
-    end
-  end
-
-  context 'when the profile indicates the user is open to opportunities' do
-    let(:job_search_status) { :open_to_opportunities }
-
-    it 'renders the caption with amber colors' do
-      render_inline(described_class.new(profile:))
-
-      figcaption = page.find('figcaption')
-      expect(figcaption[:class]).to include('amber')
-    end
-  end
-
-  context 'when the profile indicates the user is open to work' do
-    let(:job_search_status) { :open_to_work }
-
-    it 'renders the caption with green colors' do
-      render_inline(described_class.new(profile:))
-
-      figcaption = page.find('figcaption')
-      expect(figcaption[:class]).to include('green')
-    end
-  end
 end


### PR DESCRIPTION
## What's the change?
replaces the existing banner with an svg overlay

## What key workflows are impacted?
only shows overlay in the event that profile is marked `open_to_work`

## Demo / Screenshots
<img width="773" alt="Screen Shot 2023-08-27 at 1 26 24 PM" src="https://github.com/agency-of-learning/PairApp/assets/2447409/64108456-d567-4c8a-b47a-8a3577ee163a">

