### PR TITLE
Add profile links

### DIFF
--- a/app/components/profile/link_component.rb
+++ b/app/components/profile/link_component.rb
@@ -2,10 +2,10 @@
 
 class Profile::LinkComponent < ViewComponent::Base
   LINK_ICONS = {
-    github_link: 'fa-brands fa-github text-[#181717] hover:bg-[#181717]',
-    linked_in_link: 'fa-brands fa-linkedin-in text-[#0072b1] hover:bg-[#0072b1]',
+    github_link: 'fa-brands fa-github text-neutral hover:bg-neutral',
+    linked_in_link: 'fa-brands fa-linkedin-in text-linkedin-brand hover:bg-linkedin-brand',
     personal_site_link: 'fa-solid fa-link hover:bg-neutral',
-    twitter_link: 'fa-brands fa-twitter text-[#26a7de] hover:bg-[#26a7de]'
+    twitter_link: 'fa-brands fa-twitter text-twitter-brand hover:bg-twitter-brand'
   }.freeze
 
   with_collection_parameter :link_type

--- a/app/components/profile/link_component.rb
+++ b/app/components/profile/link_component.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class Profile::LinkComponent < ViewComponent::Base
+  LINK_ICONS = {
+    github_link: 'fa-brands fa-github text-[#181717] hover:bg-[#181717]',
+    linked_in_link: 'fa-brands fa-linkedin-in text-[#0072b1] hover:bg-[#0072b1]',
+    personal_site_link: 'fa-solid fa-link hover:bg-neutral',
+    twitter_link: 'fa-brands fa-twitter text-[#26a7de] hover:bg-[#26a7de]'
+  }.freeze
+
+  with_collection_parameter :link_type
+
+  def initialize(profile:, link_type:)
+    @profile = profile
+    @link_type = link_type
+  end
+
+  def call
+    link_to url, target: '_blank', rel: 'noopener' do
+      icon_tag
+    end
+  end
+
+  private
+
+  attr_reader :profile, :link_type
+
+  def url
+    @url ||= profile.public_send(link_type)
+  end
+
+  def render?
+    url.present?
+  end
+
+  def icon_tag
+    icon_class_names = LINK_ICONS.fetch(link_type)
+    general_class_names = 'fa-xl rounded-lg w-8 py-1 hover:text-primary-content transition-all'
+
+    tag.span(class: "#{icon_class_names} #{general_class_names}")
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -8,14 +8,11 @@ class ProfilesController < ApplicationController
   def edit; end
 
   def update
-    respond_to do |format|
-      if @profile.update(profile_params)
-        format.html { redirect_to @profile, success: 'Profile successfully updated!' }
-        format.turbo_stream { flash.now[:notice] = 'Profile successfully updated!' }
-      else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.turbo_stream { flash.now[:form_errors] = @profile.errors.full_messages }
-      end
+    if @profile.update(profile_params)
+      redirect_to @profile, success: 'Profile successfully updated!'
+    else
+      flash.now[:form_errors] = @profile.errors.full_messages
+      render :edit, status: :unprocessable_entity
     end
   end
 
@@ -33,6 +30,10 @@ class ProfilesController < ApplicationController
       :bio,
       :slug,
       :job_search_status,
+      :github_link,
+      :linked_in_link,
+      :personal_site_link,
+      :twitter_link,
       work_model_preferences: []
     )
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -50,6 +50,8 @@ class Profile < ApplicationRecord
   WORK_MODELS = %w[onsite hybrid remote].freeze
   validate :work_model_preferences_must_exist, :must_not_duplicate_preferences
 
+  LINK_TYPES = %i[linked_in_link github_link personal_site_link twitter_link].freeze
+
   def work_model_preferences
     super || []
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -4,10 +4,14 @@
 #
 #  id                     :bigint           not null, primary key
 #  bio                    :text
+#  github_link            :string
 #  job_search_status      :integer          default("not_job_searching")
 #  job_title              :string
+#  linked_in_link         :string
 #  location               :string
+#  personal_site_link     :string
 #  slug                   :string
+#  twitter_link           :string
 #  work_model_preferences :enum             is an Array
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -41,6 +41,16 @@ class Profile < ApplicationRecord
   validates :slug, format: { with: /\A[\w\-]+\z/, message: 'must be alphanumeric with - or _ only' }
   validates :slug, uniqueness: { case_sensitive: false, message: 'already taken' }
 
+  validates :github_link,
+    format: { with: /github.com/, message: 'must be a github link' },
+    allow_blank: true
+  validates :linked_in_link,
+    format: { with: %r{linkedin.com/in}, message: 'must be a linkedin link' },
+    allow_blank: true
+  validates :twitter_link,
+    format: { with: /twitter.com/, message: 'must be a twitter link' },
+    allow_blank: true
+
   enum job_search_status: {
     not_job_searching: 0,
     open_to_opportunities: 1,

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -42,6 +42,22 @@
       <% end %>
       <%= form.text_field :slug, required: true, pattern: '^[\-_a-zA-Z0-9]+$', class: 'input input-primary input-bordered' %>
     </div>
+    <div class="form-control">
+      <%= form.label :linked_in_link, "LinkedIn", class: 'label label-text text-lg' %>
+      <%= form.text_field :linked_in_link, class: 'input input-primary input-bordered' %>
+    </div>
+    <div class="form-control">
+      <%= form.label :github_link, "GitHub", class: 'label label-text text-lg' %>
+      <%= form.text_field :github_link, class: 'input input-primary input-bordered' %>
+    </div>
+    <div class="form-control">
+      <%= form.label :twitter_link, "Twitter", class: 'label label-text text-lg' %>
+      <%= form.text_field :twitter_link, class: 'input input-primary input-bordered' %>
+    </div>
+    <div class="form-control">
+      <%= form.label :personal_site_link, "Personal Site", class: 'label label-text text-lg' %>
+      <%= form.text_field :personal_site_link, class: 'input input-primary input-bordered' %>
+    </div>
     <div class="form-control mb-4">
       <%= form.label :bio, class: 'label label-text text-lg' %>
       <%= form.text_area :bio,

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -17,7 +17,7 @@
           <div class="badge badge-secondary badge-outline"><%= preference %></div>
         <% end %>
       </div>
-      <div class="flex gap-3">
+      <div class="flex justify-center sm:justify-start gap-3">
         <%= render Profile::LinkComponent.with_collection(Profile::LINK_TYPES, profile: @profile) %>
       </div>
     </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -10,11 +10,16 @@
       <h1 class="text-2xl font-bold"><%= @profile %></h1>
       <p class="text-xl"><%= @profile.job_title %></p>
       <% if @profile.location.present? %>
-        <p><i class="fa-solid fa-location-dot mr-2"></i><%= @profile.location %></p>
+        <p class="mb-1.5"><i class="fa-solid fa-location-dot mr-2"></i><%= @profile.location %></p>
       <% end %>
-      <% @profile.work_model_preferences.each do |preference| %>
-        <div class="badge badge-primary badge-outline"><%= preference %></div>
-      <% end %>
+      <div class="mb-2">
+        <% @profile.work_model_preferences.each do |preference| %>
+          <div class="badge badge-secondary badge-outline"><%= preference %></div>
+        <% end %>
+      </div>
+      <div class="flex gap-3">
+        <%= render Profile::LinkComponent.with_collection(Profile::LINK_TYPES, profile: @profile) %>
+      </div>
     </div>
   </div>
 

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -13,6 +13,10 @@ module.exports = {
       fontFamily: {
         sans: ["Roboto", "Inter var", ...defaultTheme.fontFamily.sans],
       },
+      colors: {
+        "twitter-brand": '#26a7de',
+        "linkedin-brand": '#0072b1',
+      }
     },
   },
   daisyui: {

--- a/db/migrate/20230827012419_add_links_to_profile.rb
+++ b/db/migrate/20230827012419_add_links_to_profile.rb
@@ -1,0 +1,8 @@
+class AddLinksToProfile < ActiveRecord::Migration[7.0]
+  def change
+    add_column :profiles, :twitter_link, :string
+    add_column :profiles, :linked_in_link, :string
+    add_column :profiles, :github_link, :string
+    add_column :profiles, :personal_site_link, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_14_195028) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_27_012419) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -136,6 +136,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_14_195028) do
     t.integer "job_search_status", default: 0
     t.enum "work_model_preferences", array: true, enum_type: "work_models_enum"
     t.string "slug"
+    t.string "twitter_link"
+    t.string "linked_in_link"
+    t.string "github_link"
+    t.string "personal_site_link"
     t.index ["slug"], name: "index_profiles_on_slug", unique: true
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end

--- a/spec/components/profile/link_component_spec.rb
+++ b/spec/components/profile/link_component_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Profile::LinkComponent, type: :component do
+  context 'when the profile does not have a link for the given type' do
+    let(:profile_without_links) { build(:profile) }
+
+    it 'renders nothing' do
+      render_inline(described_class.new(link_type: :github_link, profile: profile_without_links))
+
+      expect(page).not_to have_selector('body')
+    end
+  end
+
+  context 'when the profile has links' do
+    let(:profile_with_links) { build(:profile, :with_links) }
+
+    it 'renders the github link and icon when passed the github link type' do
+      render_inline(described_class.new(link_type: :github_link, profile: profile_with_links))
+
+      within("a[href=#{profile_with_links.github_link}]") do
+        expect(page).to have_css('.fa-github')
+      end
+    end
+
+    it 'renders the linkedin link and icon when passed the linkedin link type' do
+      render_inline(described_class.new(link_type: :linked_in_link, profile: profile_with_links))
+
+      within("a[href=#{profile_with_links.linked_in_link}]") do
+        expect(page).to have_css('.fa-linkedin-in')
+      end
+    end
+
+    it 'renders the personal site link and link icon when passed the personal site link type' do
+      render_inline(described_class.new(link_type: :personal_site_link, profile: profile_with_links))
+
+      within("a[href=#{profile_with_links.personal_site_link}]") do
+        expect(page).to have_css('.fa-link')
+      end
+    end
+
+    it 'renders the twitter link and icon when passed the twitter link type' do
+      render_inline(described_class.new(link_type: :twitter_link, profile: profile_with_links))
+
+      within("a[href=#{profile_with_links.twitter_link}]") do
+        expect(page).to have_css('.fa-twitter')
+      end
+    end
+  end
+end

--- a/spec/components/profile/link_component_spec.rb
+++ b/spec/components/profile/link_component_spec.rb
@@ -19,33 +19,29 @@ RSpec.describe Profile::LinkComponent, type: :component do
     it 'renders the github link and icon when passed the github link type' do
       render_inline(described_class.new(link_type: :github_link, profile: profile_with_links))
 
-      within("a[href=#{profile_with_links.github_link}]") do
-        expect(page).to have_css('.fa-github')
-      end
+      expect(page).to have_link(href: profile_with_links.github_link)
+      expect(page).to have_css('.fa-github')
     end
 
     it 'renders the linkedin link and icon when passed the linkedin link type' do
       render_inline(described_class.new(link_type: :linked_in_link, profile: profile_with_links))
 
-      within("a[href=#{profile_with_links.linked_in_link}]") do
-        expect(page).to have_css('.fa-linkedin-in')
-      end
+      expect(page).to have_link(href: profile_with_links.linked_in_link)
+      expect(page).to have_css('.fa-linkedin-in')
     end
 
     it 'renders the personal site link and link icon when passed the personal site link type' do
       render_inline(described_class.new(link_type: :personal_site_link, profile: profile_with_links))
 
-      within("a[href=#{profile_with_links.personal_site_link}]") do
-        expect(page).to have_css('.fa-link')
-      end
+      expect(page).to have_link(href: profile_with_links.personal_site_link)
+      expect(page).to have_css('.fa-link')
     end
 
     it 'renders the twitter link and icon when passed the twitter link type' do
       render_inline(described_class.new(link_type: :twitter_link, profile: profile_with_links))
 
-      within("a[href=#{profile_with_links.twitter_link}]") do
-        expect(page).to have_css('.fa-twitter')
-      end
+      expect(page).to have_link(href: profile_with_links.twitter_link)
+      expect(page).to have_css('.fa-twitter')
     end
   end
 end

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -36,6 +36,13 @@ FactoryBot.define do
     work_model_preferences { ['remote'] }
     slug { user.full_name.parameterize }
 
+    trait :with_links do
+      github_link { Faker::Internet.url }
+      linked_in_link { Faker::Internet.url }
+      personal_site_link { Faker::Internet.url }
+      twitter_link { Faker::Internet.url }
+    end
+
     transient do
       attached_picture { false }
     end

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -4,10 +4,14 @@
 #
 #  id                     :bigint           not null, primary key
 #  bio                    :text
+#  github_link            :string
 #  job_search_status      :integer          default("not_job_searching")
 #  job_title              :string
+#  linked_in_link         :string
 #  location               :string
+#  personal_site_link     :string
 #  slug                   :string
+#  twitter_link           :string
 #  work_model_preferences :enum             is an Array
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -37,10 +37,10 @@ FactoryBot.define do
     slug { user.full_name.parameterize }
 
     trait :with_links do
-      github_link { Faker::Internet.url }
-      linked_in_link { Faker::Internet.url }
+      github_link { Faker::Internet.url(host: 'github.com') }
+      linked_in_link { Faker::Internet.url(host: 'linkedin.com/in') }
       personal_site_link { Faker::Internet.url }
-      twitter_link { Faker::Internet.url }
+      twitter_link { Faker::Internet.url(host: 'twitter.com') }
     end
 
     transient do

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -4,10 +4,14 @@
 #
 #  id                     :bigint           not null, primary key
 #  bio                    :text
+#  github_link            :string
 #  job_search_status      :integer          default("not_job_searching")
 #  job_title              :string
+#  linked_in_link         :string
 #  location               :string
+#  personal_site_link     :string
 #  slug                   :string
+#  twitter_link           :string
 #  work_model_preferences :enum             is an Array
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null


### PR DESCRIPTION
## What's the change?
- Add fields for profile links to `Profile`
- Allow users to edit their links
- Add component for displaying profile links on the users' profile pages

## Highlights / Risks / Surprises / Cleanup
Migrate down to cleanup

## What key workflows are impacted?
Viewing and editing user profiles

## Demo / Screenshots
#### Desktop
![image](https://github.com/agency-of-learning/PairApp/assets/88392688/2efbdc72-7c5c-4100-9716-ef941a3d6c7d)

#### Mobile
![image](https://github.com/agency-of-learning/PairApp/assets/88392688/6c13985d-35bb-47b2-a424-7f8a6511ed6c)

#### Hover effect:
![profile_links_hover](https://github.com/agency-of-learning/PairApp/assets/88392688/f0b78271-c30f-4b44-9895-83dc35b1c990)

I just thought this looked nice. Glad to remove it if others don't though!

## Issue ticket number and link
Closes #187 

## Checklist before requesting a review

Please delete items that are not relevant.

- [x] Did you add appropriate automated tests?
- [x] Have you thought of misfiring code? e.g. too many loops, n+1, or how to handle nils?
- [x] Any validations to data needed?
- [x] Did you add any relevant tags and decide if this PR is a Draft vs. Ready for Review?
- [x] Do you have a plan for how this change should be rolled back? (e.g., how do you deal with a migration rollback? Is your feature released behind a feature flag?)
