### PR TITLE
Profile visibility toggling

### DIFF
--- a/app/components/profile/picture_component.html.erb
+++ b/app/components/profile/picture_component.html.erb
@@ -1,6 +1,6 @@
 <figure class="rounded-full w-64 h-64 mx-auto sm:mx-0 relative border-2 border-black bg-black mb-2">
   <div class="relative inline-block w-full object-cover rounded-full">
-    <%= image_tag profile_picture_src, class: 'h-auto max-w-full block' %>
+    <%= image_tag profile_picture_src, class: 'h-auto max-w-full rounded-full block' %>
     <% if profile.open_to_work? %>
       <div class="absolute top-0 left-0 w-full">
         <%= render inline: Rails.root.join('app/assets/images/open_to_work.svg').read %>

--- a/app/components/profile/visibility_toggle_component.html.erb
+++ b/app/components/profile/visibility_toggle_component.html.erb
@@ -1,0 +1,6 @@
+<div class="mb-6 py-2 px-4 w-fit mx-auto rounded-md <%= container_color %>">
+  <span>
+    Profile is <%= profile.visibility %>. Click <%= toggle_button %> to make it <%= opposite_state %>
+    <i class="<%= icon_class_names %> ml-2"></i>
+  </span>
+</div>

--- a/app/components/profile/visibility_toggle_component.rb
+++ b/app/components/profile/visibility_toggle_component.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class Profile::VisibilityToggleComponent < ViewComponent::Base
+  LOCK_ICONS = {
+    public: 'fa-solid fa-lock-open',
+    private: 'fa-solid fa-lock'
+  }.freeze
+
+  def initialize(profile:)
+    @profile = profile
+  end
+
+  private
+
+  attr_reader :profile
+
+  def toggle_button
+    button_to(
+      'Here',
+      profile_visibility_toggles_path(@profile),
+      class: 'link inline',
+      form_class: 'link inline'
+    )
+  end
+
+  def container_color
+    @profile.visibility == 'public' ? 'bg-primary' : 'bg-error'
+  end
+
+  def opposite_state
+    @profile.visibility == 'public' ? 'private' : 'public'
+  end
+
+  def icon_class_names
+    LOCK_ICONS.fetch(@profile.visibility.to_sym)
+  end
+end

--- a/app/components/profile/visibility_toggle_component.rb
+++ b/app/components/profile/visibility_toggle_component.rb
@@ -17,21 +17,21 @@ class Profile::VisibilityToggleComponent < ViewComponent::Base
   def toggle_button
     button_to(
       'Here',
-      profile_visibility_toggles_path(@profile),
+      profile_visibility_toggles_path(profile),
       class: 'link inline',
       form_class: 'link inline'
     )
   end
 
   def container_color
-    @profile.visibility == 'public' ? 'bg-primary' : 'bg-error'
+    profile.public_visibility? ? 'bg-primary' : 'bg-error'
   end
 
   def opposite_state
-    @profile.visibility == 'public' ? 'private' : 'public'
+    profile.public_visibility? ? 'private' : 'public'
   end
 
   def icon_class_names
-    LOCK_ICONS.fetch(@profile.visibility.to_sym)
+    LOCK_ICONS.fetch(profile.visibility.to_sym)
   end
 end

--- a/app/controllers/profiles/visibility_toggles_controller.rb
+++ b/app/controllers/profiles/visibility_toggles_controller.rb
@@ -1,0 +1,9 @@
+class Profiles::VisibilityTogglesController < ApplicationController
+  def create
+    @profile = Profile.friendly.find(params[:profile_id])
+    authorize @profile, policy_class: Profiles::VisibilityTogglePolicy
+    @profile.toggle_visibility!
+
+    redirect_to @profile
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -2,7 +2,7 @@ class ProfilesController < ApplicationController
   before_action :find_profile, except: %i[show]
 
   def show
-    @profile = Profile.includes(:user, :picture_blob).friendly.find(params[:id])
+    @profile = authorize Profile.includes(:user, :picture_blob).friendly.find(params[:id])
   end
 
   def edit; end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -87,6 +87,10 @@ class Profile < ApplicationRecord
     ]
   end
 
+  def toggle_visibility!
+    private_visibility? ? public_visibility! : private_visibility!
+  end
+
   private
 
   def move_friendly_id_error_to_slug

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -12,6 +12,7 @@
 #  personal_site_link     :string
 #  slug                   :string
 #  twitter_link           :string
+#  visibility             :integer          default("private"), not null
 #  work_model_preferences :enum             is an Array
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
@@ -56,6 +57,11 @@ class Profile < ApplicationRecord
     open_to_opportunities: 1,
     open_to_work: 2
   }
+
+  enum visibility: {
+    private: 0,
+    public: 1
+  }, _suffix: true
 
   WORK_MODELS = %w[onsite hybrid remote].freeze
   validate :work_model_preferences_must_exist, :must_not_duplicate_preferences

--- a/app/policies/profile_policy.rb
+++ b/app/policies/profile_policy.rb
@@ -2,7 +2,9 @@ class ProfilePolicy < ApplicationPolicy
   alias_method :profile, :record
 
   def show?
-    true
+    return true if profile.public_visibility?
+
+    user.present? && (matching_user? || user.admin?)
   end
 
   def update?
@@ -13,5 +15,11 @@ class ProfilePolicy < ApplicationPolicy
     def resolve
       scope.all
     end
+  end
+
+  private
+
+  def matching_user?
+    profile.user_id == user.id
   end
 end

--- a/app/policies/profiles/visibility_toggle_policy.rb
+++ b/app/policies/profiles/visibility_toggle_policy.rb
@@ -1,0 +1,7 @@
+class Profiles::VisibilityTogglePolicy < ApplicationPolicy
+  alias_method :profile, :record
+
+  def create?
+    user.id == profile.user_id
+  end
+end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,5 +1,6 @@
 <div class="max-w-prose mx-auto">
   <% if policy(@profile).edit? %>
+    <%= render Profile::VisibilityToggleComponent.new(profile: @profile) %>
     <div class="flex justify-center mb-4 px-8 sm:justify-end">
       <%= link_to "Edit Profile", edit_profile_path(@profile), class: 'btn btn-outline btn-sm text-right' %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,11 @@ Rails.application.routes.draw do
   # Shortcuts
   get 'landing/index'
 
-  resources :profiles, only: %i[show edit update]
+  resources :profiles, only: %i[show edit update] do
+    scope module: :profiles do
+      resources :visibility_toggles, only: :create
+    end
+  end
 
   resources :pair_requests, except: %i[new edit update] do
     scope module: :pair_requests do

--- a/db/migrate/20230829205928_add_visibility_to_profile.rb
+++ b/db/migrate/20230829205928_add_visibility_to_profile.rb
@@ -1,0 +1,5 @@
+class AddVisibilityToProfile < ActiveRecord::Migration[7.0]
+  def change
+    add_column :profiles, :visibility, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_28_192517) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_29_205928) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -140,6 +140,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_28_192517) do
     t.string "linked_in_link"
     t.string "github_link"
     t.string "personal_site_link"
+    t.integer "visibility", default: 0, null: false
     t.index ["slug"], name: "index_profiles_on_slug", unique: true
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end

--- a/spec/components/profile/visibility_toggle_component_spec.rb
+++ b/spec/components/profile/visibility_toggle_component_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Profile::VisibilityToggleComponent, type: :component do
+  let(:profile) { build(:profile, visibility:) }
+
+  before do
+    render_inline(described_class.new(profile:))
+  end
+
+  context 'when the profile is public' do
+    let(:visibility) { :public }
+
+    it "renders with the app's primary color" do
+      expect(page).to have_css('.bg-primary')
+    end
+
+    it "renders with the content 'Click Here to make it private'" do
+      expect(page).to have_content('Click Here to make it private')
+    end
+
+    it 'renders with the unlocked lock icon' do
+      expect(page).to have_css('.fa-lock-open')
+    end
+  end
+
+  context 'when the profile is private' do
+    let(:visibility) { :private }
+
+    it 'renders with the error color' do
+      expect(page).to have_css('.bg-error')
+    end
+
+    it "renders with the content 'Click Here to make it public'" do
+      expect(page).to have_content('Click Here to make it public')
+    end
+
+    it 'renders with the locked lock icon' do
+      expect(page).to have_css('.fa-lock')
+    end
+  end
+end

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -12,6 +12,7 @@
 #  personal_site_link     :string
 #  slug                   :string
 #  twitter_link           :string
+#  visibility             :integer          default("private"), not null
 #  work_model_preferences :enum             is an Array
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -36,6 +36,7 @@ FactoryBot.define do
     job_search_status { Profile.job_search_statuses[:not_job_searching] }
     work_model_preferences { ['remote'] }
     slug { user.full_name.parameterize }
+    visibility { Profile.visibilities[:public] }
 
     trait :with_links do
       github_link { Faker::Internet.url(host: 'github.com') }

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -12,6 +12,7 @@
 #  personal_site_link     :string
 #  slug                   :string
 #  twitter_link           :string
+#  visibility             :integer          default("private"), not null
 #  work_model_preferences :enum             is an Array
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -67,4 +67,24 @@ RSpec.describe Profile do
       expect { subject.update!(slug: 'invalid|slug') }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
+
+  describe '#toggle_visibility!' do
+    subject(:profile) { create(:profile, visibility:) }
+
+    context 'when the profile is private' do
+      let(:visibility) { :private }
+
+      it 'changes the profile to public' do
+        expect { subject.toggle_visibility! }.to change(subject, :visibility).from('private').to('public')
+      end
+    end
+
+    context 'when the profile is public' do
+      let(:visibility) { :public }
+
+      it 'changes the profile to private' do
+        expect { subject.toggle_visibility! }.to change(subject, :visibility).from('public').to('private')
+      end
+    end
+  end
 end

--- a/spec/policies/profile_policy_spec.rb
+++ b/spec/policies/profile_policy_spec.rb
@@ -3,13 +3,33 @@ require 'rails_helper'
 RSpec.describe ProfilePolicy, type: :policy do
   subject { described_class }
 
-  let(:profile) { build(:profile, user: user_with_profile) }
-  let(:user_with_profile) { build(:user) }
+  let(:profile) { create(:profile, visibility:) }
+  let(:user_with_profile) { profile.user }
   let(:random_user) { build(:user) }
+  let(:visibility) { :public }
 
   permissions :show? do
-    it 'grants access to everyone' do
-      expect(subject).to permit(random_user, profile)
+    context 'when the profile is public' do
+      it 'grants access to everyone' do
+        expect(subject).to permit(random_user, profile)
+      end
+    end
+
+    context 'when the profile is private' do
+      let(:visibility) { :private }
+      let(:admin) { build(:user, :admin) }
+
+      it 'grants access to the owning user' do
+        expect(subject).to permit(user_with_profile, profile)
+      end
+
+      it 'denies access to a random user' do
+        expect(subject).not_to permit(random_user, profile)
+      end
+
+      it 'grants access to an admin user' do
+        expect(subject).to permit(admin, profile)
+      end
     end
   end
 

--- a/spec/policies/profiles/visibility_toggle_policy_spec.rb
+++ b/spec/policies/profiles/visibility_toggle_policy_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Profiles::VisibilityTogglePolicy do
+  subject { described_class }
+
+  let(:profile) { create(:profile) }
+  let(:owning_user) { profile.user }
+  let(:random_user) { build(:user) }
+
+  permissions :create? do
+    it 'grants access when the profile belongs to the user' do
+      expect(subject).to permit(owning_user, profile)
+    end
+
+    it 'denies access when the profile does not belong to the user' do
+      expect(subject).not_to permit(random_user, profile)
+    end
+  end
+end


### PR DESCRIPTION
## What's the change?
- Add `visibility` enum field to profiles
- Users can toggle their profile between being public and private
- Adjust profile policies to restrict who can view private profiles (only the owner and admin users)

## What key workflows are impacted?
Viewing profiles

## Highlights / Surprises / Risks / Cleanup
Migrate down to cleanup

## Demo / Screenshots
![visibility_toggle](https://github.com/agency-of-learning/PairApp/assets/88392688/8e1d914f-2fbc-4f9c-a2b0-c802bc7210d5)

## Issue ticket number and link
Closes #182 

## Checklist before requesting a review

Please delete items that are not relevant.

- [x] Did you add appropriate automated tests?
- [x] Did you consider risks around security, performance, etc.?
- [x] Have you thought of misfiring code? e.g. too many loops, n+1, or how to handle nils?
- [x] Did you leave helpful inline PR comments for the reviewer(s)?
- [x] Did you add any relevant tags and decide if this PR is a Draft vs. Ready for Review?
- [x] Do you have a plan for how this change should be rolled back? (e.g., how do you deal with a migration rollback? Is your feature released behind a feature flag?)
