### PR TITLE
create more breathing room for long titled standup meeting group checkin cards

### DIFF
--- a/app/components/standup_meeting/check_in_action_component.html.erb
+++ b/app/components/standup_meeting/check_in_action_component.html.erb
@@ -1,5 +1,5 @@
 <% if standup_meeting.completed? %>
-  <%= link_to "Edit Response", 
+  <%= link_to "Edit", 
               edit_standup_meeting_group_standup_meeting_path(standup_meeting_group, standup_meeting), 
               class: 'btn btn-primary' %>
 <% elsif standup_meeting.persisted? %>

--- a/app/components/standup_meeting_group/check_in_status_component.html.erb
+++ b/app/components/standup_meeting_group/check_in_status_component.html.erb
@@ -1,11 +1,11 @@
 <% if @standup_meeting&.completed? %>
   <p class="<%= p_tag_classes %>">
-    <i class="fa-solid fa-check text-success <%= icon_classes %>"></i>
+    <i class="fa-solid fa-check text-primary <%= icon_classes %>"></i>
     Checked in
   </p>
 <% elsif @standup_meeting&.skipped? %>
   <p class="<%= p_tag_classes %>">
-    <i class="fa-solid fa-check text-success <%= icon_classes %>"></i>
+    <i class="fa-solid fa-check text-primary <%= icon_classes %>"></i>
     You skipped your check-in today
   </p>
 <% else %>

--- a/app/components/standup_meeting_group/joinable_item_component.html.erb
+++ b/app/components/standup_meeting_group/joinable_item_component.html.erb
@@ -1,8 +1,9 @@
-<%= tag.li(id: dom_id(standup_meeting_group), class: "justify-between flex flex-row p-4 mb-2 border-black border-2 items-center rounded-md") do %>
-  <%= standup_meeting_group.name %>
+<%= tag.li(id: "#{dom_id(standup_meeting_group)}-join-btn", class: "justify-between flex flex-row p-4 mb-2 border-black border-2 items-center rounded-md") do %>
   <% if my_standup_meeting_groups.include? standup_meeting_group %>
-    <%= button_to 'Leave', standup_meeting_group_join_path(standup_meeting_group, standup_meeting_group_user), method: :delete, class: 'btn btn-success', id: "#{dom_id(standup_meeting_group)}-join-btn" %>
+    <%= link_to standup_meeting_group, {}, class: 'link' %>
+    <%= button_to 'Leave', standup_meeting_group_join_path(standup_meeting_group, standup_meeting_group_user), method: :delete, class: 'btn btn-success' %>
   <% else %>
-    <%= button_to 'Join', standup_meeting_group_joins_path(standup_meeting_group), class: 'btn btn-success', id: "#{dom_id(standup_meeting_group)}-join-btn" %>
+    <%= standup_meeting_group.name %>
+    <%= button_to 'Join', standup_meeting_group_joins_path(standup_meeting_group), class: 'btn btn-success' %>
   <% end %>
 <% end %>

--- a/app/components/standup_meeting_group/joined_card_component.html.erb
+++ b/app/components/standup_meeting_group/joined_card_component.html.erb
@@ -1,7 +1,7 @@
 <%= tag.div(id: dom_id(standup_meeting_group), class: "card card-bordered w-80 shadow-md") do %>
   <div class="card-body flex p-4 ">
     <div class="flex justify-between items-center">
-      <h4 class="font-bold text-2xl"><%= link_to standup_meeting_group %></h4>
+      <h4 class="font-bold text-2xl"><%= link_to standup_meeting_group, standup_meeting_group_standup_meetings_path(standup_meeting_group) %></h4>
       <%= render StandupMeeting::CheckInActionComponent.new(standup_meeting_group:, standup_meeting:, current_user: user) %>
     </div>
     <div class="flex items-center">

--- a/app/controllers/standup_meeting_groups/joins_controller.rb
+++ b/app/controllers/standup_meeting_groups/joins_controller.rb
@@ -2,6 +2,8 @@ class StandupMeetingGroups::JoinsController < ApplicationController
   def create
     @standup_meeting_group = StandupMeetingGroup.find(params[:standup_meeting_group_id])
     @standup_meeting_group_user = @standup_meeting_group.standup_meeting_groups_users.build(user: current_user)
+    @my_standup_meeting_groups = policy_scope(StandupMeetingGroup).includes(:standup_meeting_groups_users,
+      :standup_meetings)
 
     authorize @standup_meeting_group_user, policy_class: StandupMeetingGroup::JoinPolicy
 
@@ -17,6 +19,8 @@ class StandupMeetingGroups::JoinsController < ApplicationController
   def destroy
     @standup_meeting_group = StandupMeetingGroup.find(params[:standup_meeting_group_id])
     @standup_meeting_group_user = StandupMeetingGroupUser.find(params[:id])
+    @my_standup_meeting_groups = policy_scope(StandupMeetingGroup).includes(:standup_meeting_groups_users,
+      :standup_meetings)
 
     authorize @standup_meeting_group_user, policy_class: StandupMeetingGroup::JoinPolicy
 

--- a/app/views/standup_meeting_groups/joins/create.turbo_stream.erb
+++ b/app/views/standup_meeting_groups/joins/create.turbo_stream.erb
@@ -2,9 +2,5 @@
   <%= render StandupMeetingGroup::JoinedCardComponent.new(standup_meeting_group: @standup_meeting_group, current_user: current_user) %>
 <% end %>
 <%= turbo_stream.replace "#{dom_id(@standup_meeting_group)}-join-btn" do %>
-  <%= button_to 'Leave',
-                standup_meeting_group_join_path(@standup_meeting_group, @standup_meeting_group_user),
-                method: :delete,
-                class: 'btn btn-success',
-                id: "#{dom_id(@standup_meeting_group)}-join-btn" %>
+  <%= render StandupMeetingGroup::JoinableItemComponent.new(standup_meeting_group: @standup_meeting_group, my_standup_meeting_groups: @my_standup_meeting_groups, current_user: current_user) %>
 <% end %>

--- a/app/views/standup_meeting_groups/joins/destroy.turbo_stream.erb
+++ b/app/views/standup_meeting_groups/joins/destroy.turbo_stream.erb
@@ -2,5 +2,5 @@
   <%= render StandupMeetingGroup::JoinableItemComponent.new(standup_meeting_group: @standup_meeting_group, current_user: current_user ) %>
 <% end %>
 <%= turbo_stream.replace "#{dom_id(@standup_meeting_group)}-join-btn" do %>
-  <%= button_to 'Join', standup_meeting_group_joins_path(@standup_meeting_group), class: 'btn btn-success', id: "#{dom_id(@standup_meeting_group)}-join-btn" %>
+  <%= render StandupMeetingGroup::JoinableItemComponent.new(standup_meeting_group: @standup_meeting_group, my_standup_meeting_groups: @my_standup_meeting_groups, current_user: current_user) %>
 <% end %>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -14,9 +14,9 @@ module.exports = {
         sans: ["Roboto", "Inter var", ...defaultTheme.fontFamily.sans],
       },
       colors: {
-        "twitter-brand": '#26a7de',
-        "linkedin-brand": '#0072b1',
-      }
+        "twitter-brand": "#26a7de",
+        "linkedin-brand": "#0072b1",
+      },
     },
   },
   daisyui: {
@@ -48,6 +48,7 @@ module.exports = {
     safelist: [
       "alert-error",
       "alert-success",
+      "text-success",
       "border-success",
       "border-error",
       "bg-success",

--- a/spec/components/standup_meeting/check_in_action_component_spec.rb
+++ b/spec/components/standup_meeting/check_in_action_component_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe StandupMeeting::CheckInActionComponent, type: :component do
   context 'when the standup meeting is completed' do
     let(:status) { :completed }
 
-    it 'renders an Edit Response link' do
+    it 'renders an Edit link' do
       render_inline(described_class.new(standup_meeting_group:, standup_meeting:, current_user: user))
 
-      expect(page).to have_link('Edit Response')
+      expect(page).to have_link('Edit')
     end
   end
 end


### PR DESCRIPTION
## What's the change?
A bit more breathing room to the standup meeting groups cards.

Also, I noticed that because the CTA is focused on the current day's standup, it seemed confusing the clicking it takes me to the group overview rather than the current day's standup. This PR also changes it so that clicking the title of the group in the CTA takes you to the day's standup, while clicking the joined standup group below takes you to the overview

## Demo / Screenshots
### Before:
<img width="1728" alt="Screen Shot 2023-09-05 at 10 27 34 PM" src="https://github.com/agency-of-learning/PairApp/assets/2447409/68f21d5d-fb3c-4e7a-a2c5-c99e5aecf9ea">

### After:
<img width="1728" alt="Screen Shot 2023-09-05 at 10 48 09 PM" src="https://github.com/agency-of-learning/PairApp/assets/2447409/8b56692c-d9ff-4c94-8675-9dc6e9b29a0c">
## Issue ticket number and link


## Checklist before requesting a review

Please delete items that are not relevant.

- [X] Did you add appropriate automated tests?
- [X] Did you consider risks around security, performance, etc.?
- [X] Have you thought of misfiring code? e.g. too many loops, n+1, or how to handle nils?