### PR TITLE
scope pair requests to active members

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,6 +83,8 @@ class User < ApplicationRecord
 
   after_create :create_profile!
 
+  scope :members, -> { where(role: :member) }
+
   def self.invite!(attributes = {}, invited_by = nil, options = {}, &)
     default_name = { first_name: 'First', last_name: 'Last' }
     super(attributes.merge(default_name), invited_by, options, &)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,7 +83,7 @@ class User < ApplicationRecord
 
   after_create :create_profile!
 
-  scope :members, -> { where(role: :member) }
+  scope :members, -> { where(role: [:member, :admin]) }
 
   def self.invite!(attributes = {}, invited_by = nil, options = {}, &)
     default_name = { first_name: 'First', last_name: 'Last' }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,7 +83,7 @@ class User < ApplicationRecord
 
   after_create :create_profile!
 
-  scope :members, -> { where(role: [:member, :admin]) }
+  scope :members, -> { where(role: %i[member admin]) }
 
   def self.invite!(attributes = {}, invited_by = nil, options = {}, &)
     default_name = { first_name: 'First', last_name: 'Last' }

--- a/app/views/pair_requests/_form.html.erb
+++ b/app/views/pair_requests/_form.html.erb
@@ -4,7 +4,7 @@
       <div class="flex justify-between space-x-4 align-middle items-center ">
          <%= form.label :invitee_id, class: "label label-text" %>
          <%= form.select :invitee_id, nil, { :include_blank => "Please select" }, { class: "select select-primary", data: { action: "change->pair-requests-form#onClick", "pair-requests-form-target" => "inviteeInfo"}} do %>
-          <% User.excluding(current_user).each do |invitee| %>
+          <% User.members.excluding(current_user).each do |invitee| %>
             <%= tag.option(invitee.full_name, value: invitee.id, data: { "time-zone-identifier" => invitee.time_zone_identifier, "time-zone-display-name" => invitee.time_zone, "user-time-zone" => current_user.time_zone_identifier}) %>
           <% end %>
         <% end %>


### PR DESCRIPTION
## What's the change?
Bug fix. Scopes pair request users to active members. Adds a `members` scope.
 
## What key workflows are impacted?
Makes pair requests more usable again.

## Highlights / Surprises / Risks / Cleanup
## Demo / Screenshots

## Issue ticket number and link
closes #290 . Test by checking out the pair request index page and selecting the dropdown. You should only see members or admin.
