### PR TITLE
Default hours to 0 on application

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
     timestamp.strftime('%B %d, %Y at %l:%M %p')
   end
 
-  # rubocop:disable Style/PerceivedComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def pagy_nav(pagy, pagy_id: nil, link_extra: '', **vars)
     p_id   = %[ id="#{pagy_id}"] if pagy_id
     link   = pagy_link_proc(pagy, link_extra:)
@@ -38,7 +38,7 @@ module ApplicationHelper
             end
     html << %[</nav>]
   end
-  # rubocop:enable Style/PerceivedComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
 
   def background_color
     'bg-[#2C2E36]' if current_page?(root_path)

--- a/app/models/user_mentee_application.rb
+++ b/app/models/user_mentee_application.rb
@@ -40,7 +40,7 @@ class UserMenteeApplication < ApplicationRecord
                           }, class_name: 'MenteeApplicationState', dependent: nil
   # rubocop:enable Rails/InverseOf
 
-  validates :available_hours_per_week, numericality: { greater_than: 0, less_than_or_equal_to: 60 }
+  validates :available_hours_per_week, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 60 }
 
   validates :city, :state, :country, :reason_for_applying, :learned_to_code, :project_experience,
     :available_hours_per_week, presence: true

--- a/app/views/user_mentee_applications/new.html.erb
+++ b/app/views/user_mentee_applications/new.html.erb
@@ -26,13 +26,13 @@
         <%= form.text_field :referral_source, class: 'input input-bordered mb-2' %>
       </div>
 
-      <div class="flex flex-col form-control">
+      <div class="flex flex-col form-control items-start">
         <%= form.label :available_hours_per_week, 'How many hours per week are you able to commit to The Agency of Learning?', class: 'label-text mb-1' %>
         <%= form.number_field :available_hours_per_week,
-          min: 1,
+          min: 0,
           max: 60,
-          value: @user_mentee_application.available_hours_per_week.presence || 1,
-          class: 'input input-sm input-bordered',
+          value: @user_mentee_application.available_hours_per_week.presence || 0,
+          class: 'input input-bordered',
           required: true
         %>
       </div>


### PR DESCRIPTION
## What's the change?
- Application defaults to 0 hours, forcing the user to consciously change what's in the field.

## What key workflows are impacted?
Filling out an application

## Highlights / Surprises / Risks / Cleanup
One thing I thought was maybe a bit confusing is if we want to allow them to submit with this field still sitting at 0? Currently it allows this, although it'd be a super easy fix for me to make the minimum submit value greater than or equal to 1 (while still having the input default to 0).

## Demo / Screenshots
![Selection_293](https://github.com/agency-of-learning/PairApp/assets/88392688/21407029-1ce5-4b35-92d9-b5319b70b7ba)

## Issue ticket number and link
Closes #296

## Checklist before requesting a review

Please delete items that are not relevant.

- [x] Any validations to data needed?
