### PR TITLE
authorize index page access based on whether user is an applicant

### DIFF
--- a/app/controllers/user_mentee_applications_controller.rb
+++ b/app/controllers/user_mentee_applications_controller.rb
@@ -3,6 +3,7 @@ class UserMenteeApplicationsController < ApplicationController
   before_action :set_active_cohort, only: %i[index new create]
 
   def index
+    authorize current_user, policy_class: UserMenteeApplicationPolicy
     @user_mentee_applications = current_user
                                 .mentee_applications
                                 .order_newest_first

--- a/app/controllers/user_mentee_applications_controller.rb
+++ b/app/controllers/user_mentee_applications_controller.rb
@@ -3,7 +3,7 @@ class UserMenteeApplicationsController < ApplicationController
   before_action :set_active_cohort, only: %i[index new create]
 
   def index
-    authorize current_user, policy_class: UserMenteeApplicationPolicy
+    authorize :user_only_policy, :applicant?
     @user_mentee_applications = current_user
                                 .mentee_applications
                                 .order_newest_first

--- a/app/policies/user_mentee_application_policy.rb
+++ b/app/policies/user_mentee_application_policy.rb
@@ -1,6 +1,6 @@
 class UserMenteeApplicationPolicy < ApplicationPolicy
   def index?
-    user.admin?
+    user.applicant?
   end
 
   def show?

--- a/app/policies/user_only_policy.rb
+++ b/app/policies/user_only_policy.rb
@@ -6,5 +6,5 @@ class UserOnlyPolicy
   end
 
   # the delegate method forwards the admin? method call @user's admin? method
-  delegate :admin?, to: :user
+  delegate :admin?, :applicant?, to: :user
 end

--- a/spec/policies/user_mentee_application_policy_spec.rb
+++ b/spec/policies/user_mentee_application_policy_spec.rb
@@ -6,14 +6,16 @@ RSpec.describe UserMenteeApplicationPolicy, type: :policy do
   let(:user) { build(:user) }
   let(:random_user) { build(:user) }
   let(:admin) { build(:user, :admin) }
+  let(:applicant) { build(:user, :applicant) }
 
   permissions :index? do
-    it 'allows access to admin' do
-      expect(subject).to permit(admin, StandupMeeting)
+    it 'allows access to applicant' do
+      expect(subject).to permit(applicant, StandupMeeting)
     end
 
-    it 'denies access to non-admin' do
-      expect(subject).not_to permit(user, StandupMeeting)
+    it 'denies access to non-applicants' do
+      expect(subject).not_to permit(admin, StandupMeeting)
+      expect(subject).not_to permit(random_user, StandupMeeting)
     end
   end
 


### PR DESCRIPTION
## What's the change?
Only authorize applicants to view UserMenteeApplications#index

That page isn't relevant to admins the information can be accessed using specific cohort show pages.

## Issue ticket number and link
closes #316 
