### PR TITLE
Add social media validations to mentee application model for mentee application form

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -456,6 +456,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-20
   x86_64-linux
 

--- a/app/models/user_mentee_application.rb
+++ b/app/models/user_mentee_application.rb
@@ -45,6 +45,14 @@ class UserMenteeApplication < ApplicationRecord
   validates :city, :state, :country, :reason_for_applying, :learned_to_code, :project_experience,
     :available_hours_per_week, presence: true
 
+  validates :github_url,
+    format: { with: %r{/github.com/}, message: 'must be a github url' },
+    allow_blank: true
+
+  validates :linkedin_url,
+    format: { with: %r{linkedin.com/in}, message: 'must be a linkedin url' },
+    allow_blank: true
+
   after_create :create_initial_application_state
   after_create_commit :send_application_submission_notifications
 

--- a/spec/factories/user_mentee_applications.rb
+++ b/spec/factories/user_mentee_applications.rb
@@ -34,14 +34,17 @@ FactoryBot.define do
     user { association :user, :applicant }
     user_mentee_application_cohort
 
+    learned_to_code { Faker::Lorem.paragraph }
+    project_experience { Faker::Lorem.paragraph }
+    reason_for_applying { 'Help with job search' }
+
     available_hours_per_week { 10 }
     city { Faker::Address.city }
     state { Faker::Address.state }
     country { Faker::Address.country }
 
-    learned_to_code { Faker::Lorem.paragraph }
-    project_experience { Faker::Lorem.paragraph }
-    reason_for_applying { 'Help with job search' }
+    github_url { 'https://github.com/user' }
+    linkedin_url { 'https://www.linkedin.com/in/user/' }
 
     trait :with_resume do
       after(:create) do |user_mentee_application|

--- a/spec/models/user_mentee_application_spec.rb
+++ b/spec/models/user_mentee_application_spec.rb
@@ -110,4 +110,52 @@ RSpec.describe UserMenteeApplication do
           :notify_for_application_submission).exactly(User.super_admins.count).times
     end
   end
+
+  describe '#available_hours_per_week' do
+    it 'is valid' do
+      expect(mentee_application).to be_valid
+    end
+
+    context 'when available hours per week is not within valid range' do
+      subject { build_stubbed(:user_mentee_application, available_hours_per_week:) }
+
+      let(:available_hours_per_week) { -1 }
+
+      it 'is invalid' do
+        expect(subject).not_to be_valid
+      end
+    end
+  end
+
+  describe '#github_url' do
+    it 'is valid' do
+      expect(mentee_application).to be_valid
+    end
+
+    context 'when a github_url is not entered' do
+      subject { build_stubbed(:user_mentee_application, github_url:) }
+
+      let(:github_url) { 'https://www.example.com' }
+
+      it 'is invalid' do
+        expect(subject).not_to be_valid
+      end
+    end
+  end
+
+  describe '#linkedin_url' do
+    it 'is valid' do
+      expect(mentee_application).to be_valid
+    end
+
+    context 'when a github_url is not entered' do
+      subject { build_stubbed(:user_mentee_application, linkedin_url:) }
+
+      let(:linkedin_url) { 'https://www.example.com' }
+
+      it 'is invalid' do
+        expect(subject).not_to be_valid
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What's the change?
Added social media validations to user_mentee_application model for mentee application form
## What key workflows are impacted?
mentee application form

## Demo / Screenshots
https://github.com/agency-of-learning/PairApp/assets/74928397/4cbe89ab-7da2-48ef-bf0a-06481e31ee92

## Issue ticket number and link
#314 

## Checklist before requesting a review
- Added specs for social media validations and also for the 'available_hours_per_week' validation
- Did not add a spec for:

`validates :city, :state, :country, :reason_for_applying, :learned_to_code, :project_experience,
    :available_hours_per_week, presence: true`


