### PR TITLE
reduce friction by filling out some fields with info from last submitted application

### DIFF
--- a/app/controllers/user_mentee_applications_controller.rb
+++ b/app/controllers/user_mentee_applications_controller.rb
@@ -23,7 +23,16 @@ class UserMenteeApplicationsController < ApplicationController
     if @active_cohort.application_for_user?(current_user)
       redirect_to user_mentee_applications_path
     else
-      @user_mentee_application = UserMenteeApplication.new
+      latest_application = current_user.mentee_applications.last
+      @user_mentee_application = UserMenteeApplication.new(
+        github_url: latest_application&.github_url,
+        linkedin_url: latest_application&.linkedin_url,
+        referral_source: latest_application&.referral_source,
+        city: latest_application&.city,
+        state: latest_application&.state,
+        country: latest_application&.country,
+        learned_to_code: latest_application&.learned_to_code,
+      )
     end
   end
 

--- a/app/controllers/user_mentee_applications_controller.rb
+++ b/app/controllers/user_mentee_applications_controller.rb
@@ -31,7 +31,7 @@ class UserMenteeApplicationsController < ApplicationController
         city: latest_application&.city,
         state: latest_application&.state,
         country: latest_application&.country,
-        learned_to_code: latest_application&.learned_to_code,
+        learned_to_code: latest_application&.learned_to_code
       )
     end
   end


### PR DESCRIPTION
## What's the change?
Right now, we force participants who are reapplying to fill in a lot of information that they already provided us on their new application.

Some aspects of their application are not likely to change. In order to best respect their time, I propose filling out fields with data that are already in our system that are unlikely to have changed.

I have purposefully not added the "Describe a project you’ve worked on that you especially loved or are proud of" as that might have changed since the last application and would help showcase their growth.

Similarly, their reason for joining might have changed, so I left that blank for them to add.

## What key workflows are impacted?
User Mentee Application takes less time to complete.
