### PR TITLE
322 notify prior cohorts to reapply

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,8 @@ To set up this project, you need to have the following software installed on you
 - [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) (Follow the link for installation instructions)
 
 For detailed instructions on how to install these dependencies, please reference our [Wiki step-by-step guide for installing dependencies on Mac or Windows](https://github.com/agency-of-learning/PairApp/wiki/Step%E2%80%90by%E2%80%90step-instructions-to-install-the-dependencies-of-our-application).
-## 12factor Approach
 
-This project follows the [12factor methodology](https://12factor.net/) for building software-as-a-service applications. Specifically, this project adheres to the following 12 factors:
-
-- **Codebase:** One codebase tracked in version control, many deploys
-- **Dependencies:** Explicitly declare and isolate dependencies
-- **Config:** Store config in the environment
-- **Backing services:** Treat backing services as attached resources
-- **Build, release, run:** Strictly separate build and run stages
-- **Processes:** Execute the app as one or more stateless processes
-- **Port binding:** Export services via port binding
-- **Concurrency:** Scale out via the process model
-- **Disposability:** Maximize robustness with fast startup and graceful shutdown
-- **Dev/prod parity:** Keep development, staging, and production as similar as possible
-- **Logs:** Treat logs as event streams
-- **Admin processes:** Run admin/management tasks as one-off processes
+You can view open issues [here](https://github.com/orgs/agency-of-learning/projects/1/views/1)
 
 ## Getting Started
 
@@ -60,30 +46,6 @@ bin/dev
 ```
 
 This will start the development server, the asset compiling for CSS and JS, and background worker. Open your web browser and go to http://localhost:3000 to see the application running.
-
-## Working with Devise Invitable
-
-If you need to work with the user registration/invitation process, follow these steps:
-
-1. Make sure you are logged out of the application.
-
-2. Open a Rails console session:
-
-```bash
-rails console
-```
-
-3. In the console, run the following command to invite a user:
-
-```bash
-User.invite!(email: <some_test_email>)
-```
-
-4. You can access the letter by opening http://localhost:3000/letter_opener (dev only).
-
-5. Click the invite link to get to the sign-up page where you can set a password. This will create a fully active account with the provided email and password.
-
-Note: This flow is only necessary if you're building something around the user registration/invitation process. If you just want to create users, you can use User.create(\*\*attrs) as usual.
 
 ## Contributing
 

--- a/app/mailers/mentee_application_mailer.rb
+++ b/app/mailers/mentee_application_mailer.rb
@@ -17,4 +17,9 @@ class MenteeApplicationMailer < ApplicationMailer
   def notify_for_code_challenge_approved
     mail(subject: 'Moving forward in the application process for the Agency of Learning')
   end
+
+  def notify_for_reapplication
+    @active_cohort_name = params[:active_cohort_name]
+    mail(subject: 'Invitation to Apply to the Agency of Learning')
+  end
 end

--- a/app/mailers/mentee_application_mailer.rb
+++ b/app/mailers/mentee_application_mailer.rb
@@ -1,4 +1,6 @@
 class MenteeApplicationMailer < ApplicationMailer
+  default from: 'dave@agencyoflearning.com'
+
   def notify_for_acceptance
     @application = params[:application]
     mail(subject: 'Welcome to the Agency of Learning!')

--- a/app/mailers/user_mentee_application_mailer.rb
+++ b/app/mailers/user_mentee_application_mailer.rb
@@ -1,4 +1,6 @@
 class UserMenteeApplicationMailer < ApplicationMailer
+  default from: 'dave@agencyoflearning.com'
+
   def notify_for_application_submission
     @user_mentee_application = params[:user_mentee_application]
     mail(subject: 'Woohoo! Your Application’s In - Agency of Learning.')

--- a/app/notifications/mentee_application/reapplication_notification.rb
+++ b/app/notifications/mentee_application/reapplication_notification.rb
@@ -1,0 +1,19 @@
+# To deliver this notification:
+#
+# MenteeApplication::ReapplicationNotification.with(post: @post).deliver_later(current_user)
+# MenteeApplication::ReapplicationNotification.with(post: @post).deliver(current_user)
+
+class MenteeApplication::ReapplicationNotification < Noticed::Base
+  deliver_by :email,
+    mailer: 'MenteeApplicationMailer',
+    method: :notify_for_reapplication,
+    enqueue: true
+
+  # Add required params
+  #
+  param :active_cohort_name
+
+  def active_cohort_name
+    params[:active_cohort_name]
+  end
+end

--- a/app/notifications/mentee_application/reapplication_notification.rb
+++ b/app/notifications/mentee_application/reapplication_notification.rb
@@ -9,11 +9,5 @@ class MenteeApplication::ReapplicationNotification < Noticed::Base
     method: :notify_for_reapplication,
     enqueue: true
 
-  # Add required params
-  #
   param :active_cohort_name
-
-  def active_cohort_name
-    params[:active_cohort_name]
-  end
 end

--- a/app/views/mentee_application_mailer/notify_for_reapplication.html.erb
+++ b/app/views/mentee_application_mailer/notify_for_reapplication.html.erb
@@ -20,10 +20,10 @@
   <h4>Reset your password</h4>
   <ol>
     <li>
-      Navigate to <a href="https://pair.agencyoflearning.com/users/sign_in">the agency's pair application sign in form</a>
+      Navigate to <%= link_to "the agency's pair application sign in form", new_user_session_url %>
     </li>
     <li>
-      Click on the <a href="https://pair.agencyoflearning.com/users/password/new">Forgot your Password</a> link
+      Click on the <%= link_to "Forgot your Password", new_user_password_url %> link
     </li>
     <li>
       Enter your email address: <strong><%= @recipient.email %></strong>
@@ -52,6 +52,6 @@
     Best,
   </p>
   <p>
-    Dave Paola | <a href="https://pair.agencyoflearning.com">Agency of Learning</a>
+    Dave Paola | <%= link_to "Agency of Learning", root_url %>
   </p>
 </div>

--- a/app/views/mentee_application_mailer/notify_for_reapplication.html.erb
+++ b/app/views/mentee_application_mailer/notify_for_reapplication.html.erb
@@ -1,0 +1,57 @@
+
+<div style='display: block; max-width: 40rem; margin: 0 auto; padding-top: 4rem; line-height: 1.3rem; padding: 0.25rem'>
+  <p>Dear <%= @recipient.full_name %>,</p>
+  <p>
+    Thank you for previously expressing interest to join us at the Agency of Learning.
+  </p>
+
+  <p>
+    We are currently opening our upcoming <%= @active_cohort_name %> cohort to early-career developers with some experience using Ruby on Rails to join us. In particular, we are looking for applicants residing in North America who can devote at least 10 hours per week to the Agency.
+  </p>
+
+  <p>
+    Given your previous interest, we wanted to invite you to <strong>reapply to the Agency of Learning</strong>. To speed things up, we've filled in your reapplication form with information from your previous application.
+  </p>
+
+  <p>
+    To reapply, please follow these steps:
+  </p>
+
+  <h4>Reset your password</h4>
+  <ol>
+    <li>
+      Navigate to <a href="https://pair.agencyoflearning.com/users/sign_in">the agency's pair application sign in form</a>
+    </li>
+    <li>
+      Click on the <a href="https://pair.agencyoflearning.com/users/password/new">Forgot your Password</a> link
+    </li>
+    <li>
+      Enter your email address: <strong><%= @recipient.email %></strong>
+    </li>
+    <li>
+      Once the password reset email enters your inbox, follow the link and reset your password to log in to the Agency's portal
+    </li>
+  </ol>
+  <h4>Submit a new application</h4>
+  <ol>
+    <li>
+      At the top of the page, you should see a button inviting you to <strong>"Click to Reapply"</strong>.
+    </li>
+    <li>
+      Fill out the form
+    </li>
+    <li>
+      Submit
+    </li>
+  </ol>
+  
+  <p>
+    We look forward to reviewing your application! 
+  </p>
+  <p>
+    Best,
+  </p>
+  <p>
+    Dave Paola | <a href="https://pair.agencyoflearning.com">Agency of Learning</a>
+  </p>
+</div>

--- a/app/views/user_mentee_application_mailer/notify_for_application_submission.html.erb
+++ b/app/views/user_mentee_application_mailer/notify_for_application_submission.html.erb
@@ -11,3 +11,5 @@
   
   <p>Best,<br>
   Your Friends at Agency of Learning</p>
+
+  <p>If you have any questions or concerns, feel free to reply to this email. Dave's here to help!</p>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -59,8 +59,7 @@ begin
   puts 'Seeding completed pair requests with feedback drafts...'
 
   completed_pair_request_data = Array.new(5) do
-    author, invitee = users.sample(2)
-    { status: 'completed', author:, invitee:, when: 30.minutes.ago, duration: 30.minutes }
+    generate_pair_request_data(users:, status: 'completed', pair_date: 30.minutes.ago)
   end
 
   PairRequest.transaction do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,9 +6,9 @@ def generate_user_data(role:, idx:)
   { first_name: role.capitalize, last_name: Faker::Name.last_name, email:, password: 'password', role: }
 end
 
-def generate_pair_request_data(users:, status:)
+def generate_pair_request_data(users:, status:, pair_date: nil)
   author, invitee = users.sample(2)
-  pair_date = [1, 2, 3, 4].sample.day.from_now
+  pair_date ||= [1, 2, 3, 4].sample.day.from_now
   { status:, author:, invitee:, when: pair_date, duration: 30.minutes }
 end
 
@@ -46,7 +46,7 @@ begin
   5.times do
     pair_request_data.push(generate_pair_request_data(status: 'pending', users:))
     pair_request_data.push(generate_pair_request_data(status: 'rejected', users:))
-    pair_request_data.push(generate_pair_request_data(status: 'accepted', users:))
+    pair_request_data.push(generate_pair_request_data(status: 'accepted', users:, pair_date: Time.now))
   end
 
   PairRequest.transaction do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,70 +1,78 @@
 require 'faker'
+
+def generate_user_data(role:, idx:)
+  raise StandardError, 'Invalid role' unless User.roles.key?(role)
+  email = idx.zero? ? "#{role}@aol.com" : "#{role}#{idx}@aol.com"
+  { first_name: role.capitalize, last_name: Faker::Name.last_name, email:, password: 'password', role: }
+end
+
+def generate_pair_request_data(users:, status:)
+  author, invitee = users.sample(2)
+  pair_date = [1, 2, 3, 4].sample.day.from_now
+  { status:, author:, invitee:, when: pair_date, duration: 30.minutes }
+end
+
 begin
-  puts "Seeding users..."
+  puts 'Seeding users...'
 
-  user_data = [
-    { first_name: 'Admin', last_name: Faker::Name.last_name, email: "admin@aol.com", password: "password", role: "admin" },
-    { first_name: 'Mod', last_name: Faker::Name.last_name, email: "mod@aol.com", password: "password", role: "moderator" },
-    { first_name: 'User1', last_name: Faker::Name.last_name, email: "user1@aol.com", password: "password", role: "member" },
-    { first_name: 'User2', last_name: Faker::Name.last_name, email: "user2@aol.com", password: "password", role: "member" },
-    { first_name: 'User3', last_name: Faker::Name.last_name, email: "user3@aol.com", password: "password", role: "member" },
-    { first_name: 'Applicant1', last_name: Faker::Name.last_name, email: "applicant1@aol.com", password: "password", role: "applicant" },
-    { first_name: 'Applicant2', last_name: Faker::Name.last_name, email: "applicant2@aol.com", password: "password", role: "applicant" },
-    { first_name: 'Applicant3', last_name: Faker::Name.last_name, email: "applicant3@aol.com", password: "password", role: "applicant" },
-  ]
+  user_data = []
+  # create admin and mod data
+  2.times do |idx|
+    user_data.push(generate_user_data(role: 'admin', idx:))
+    user_data.push(generate_user_data(role: 'moderator', idx:))
+  end
 
-  users = []
+  # create member data
+  4.times do |idx|
+    user_data.push(generate_user_data(role: 'member', idx:))
+  end
+
+  # create applicant data
+  24.times do |idx|
+    user_data.push(generate_user_data(role: 'applicant', idx:))
+  end
 
   User.transaction do
     user_data.each do |data|
-      user = User.create!(data)
-      users << user
-      puts "User #{user.email} created"
+      User.create!(data)
+      puts "User #{data[:email]} created"
     end
   end
-  puts "Users seeded successfully!"
+  users = User.all
+  puts 'Users seeded successfully!'
 
-  puts "Seeding pair requests..."
-  pair_request_data = [
-    { status: "pending", author: users[1], invitee: users[2], when: 1.day.from_now, duration: 30.minutes },
-    { status: "pending", author: users[1], invitee: users[3], when: 1.day.from_now, duration: 30.minutes },
-    { status: "pending", author: users[2], invitee: users[3], when: 1.day.from_now, duration: 45.minutes },
-    { status: "rejected", author: users[1], invitee: users[2], when: 1.day.from_now, duration: 30.minutes },
-    { status: "accepted", author: users[1], invitee: users[2], when: 5.day.from_now, duration: 60.minutes },
-    { status: "accepted", author: users[2], invitee: users[3], when: Time.now, duration: 60.minutes },
-    { status: "accepted", author: users[2], invitee: users[3], when: Time.now, duration: 60.minutes },
-    { status: "accepted", author: users[2], invitee: users[3], when: Time.now, duration: 60.minutes },
-    { status: "accepted", author: users[3], invitee: users[2], when: Time.now, duration: 60.minutes },
-    { status: "accepted", author: users[3], invitee: users[2], when: Time.now, duration: 60.minutes },
-    { status: "rejected", author: users[3], invitee: users[1], when: 20.days.from_now, duration: 15.minutes },
-  ]
+  puts 'Seeding pair requests...'
+  pair_request_data = []
+  5.times do
+    pair_request_data.push(generate_pair_request_data(status: 'pending', users:))
+    pair_request_data.push(generate_pair_request_data(status: 'rejected', users:))
+    pair_request_data.push(generate_pair_request_data(status: 'accepted', users:))
+  end
 
   PairRequest.transaction do
     pair_request_data.each do |data|
       PairRequest.create!(data)
     end
   end
-  puts "Pair requests seeded successfully!"
+  puts 'Pair requests seeded successfully!'
 
-  puts "Seeding completed pair requests with feedback drafts..."
-  completed_pair_request_data =[
-  { status: "completed", author: users[1], invitee: users[2], when: Time.current - 30.minutes,  duration: 30.minutes },
-  { status: "completed", author: users[1], invitee: users[2], when: Time.current - 60.minutes,  duration: 30.minutes },
-  { status: "completed", author: users[1], invitee: users[3], when: Time.current - 45.minutes,  duration: 30.minutes },
-  { status: "completed", author: users[3], invitee: users[1], when: Time.current - 60.minutes,  duration: 30.minutes },
-  { status: "completed", author: users[2], invitee: users[1], when: Time.current - 50.minutes,  duration: 30.minutes },
-  ]
-  
+  puts 'Seeding completed pair requests with feedback drafts...'
+
+  completed_pair_request_data = Array.new(5) do
+    author, invitee = users.sample(2)
+    { status: 'completed', author:, invitee:, when: 30.minutes.ago, duration: 30.minutes }
+  end
+
   PairRequest.transaction do
     completed_pair_request_data.each do |data|
       PairRequest.create!(data).create_draft_feedback!
     end
   end
 
-  puts "Seeding a Standup Meeting Group"
+  puts 'Seeding a Standup Meeting Group'
   standup_meeting_group = StandupMeetingGroup.create!(
     name: 'PairApp',
-    start_time: Time.new(2023,1,1,9,0,0)
+    start_time: Time.new(2023, 1, 1, 9, 0, 0)
   )
 
   users.each do |user|
@@ -77,70 +85,46 @@ begin
       )
     end
   end
-  puts "Completed seeding standup meeting group!"
+  puts 'Completed seeding standup meeting group!'
 
+  puts 'Seeding a user_mentee_application...'
 
-  puts "Seeding a user_mentee_application..."
-
-  cohort = UserMenteeApplicationCohort.create!(
-    name: 'Original',
-    active_date_range: Date.today..3.months.from_now
+  # Current upcoming cohort
+  active_cohort = UserMenteeApplicationCohort.create!(
+    name: 'Fall 2023',
+    active_date_range: Time.zone.today..3.months.from_now
   )
 
-  user_mentee_application_data = [
+  original_cohort = UserMenteeApplicationCohort.create!(
+    name: 'Original',
+    active_date_range: 3.months.ago..Date.yesterday,
+    active: false
+  )
+
+  applicants = users.where(role: User.roles[:applicant])
+  user_mentee_application_data = applicants.map.with_index do |applicant, idx|
     {
-      user_id: users[4].id,
-      user_mentee_application_cohort: cohort,
-      city: Faker::Address.city,
-      state: Faker::Address.state,
-      country: Faker::Address.country,
-      reason_for_applying: Faker::Lorem.paragraph, 
-      linkedin_url: Faker::Internet.url, 
-      github_url: Faker::Internet.url, 
-      learned_to_code: Faker::Lorem.paragraph, 
-      project_experience: Faker::Lorem.paragraph, 
-      available_hours_per_week: 10, 
-      referral_source: Faker::Lorem.paragraph, 
-      additional_information: Faker::Lorem.paragraph
-    },
-    {
-      user_id: users[5].id,
-      user_mentee_application_cohort: cohort,
+      user_id: applicant.id,
+      user_mentee_application_cohort: idx.even? ? active_cohort : original_cohort,
       city: Faker::Address.city,
       state: Faker::Address.state,
       country: Faker::Address.country,
       reason_for_applying: Faker::Lorem.paragraph,
-      linkedin_url: Faker::Internet.url,
-      github_url: Faker::Internet.url,
-      learned_to_code: Faker::Lorem.paragraph,
-      project_experience: Faker::Lorem.paragraph,
-      available_hours_per_week: 10,
-      referral_source: Faker::Lorem.paragraph,
-      additional_information: Faker::Lorem.paragraph
-    },
-    {
-      user_id: users[6].id,
-      user_mentee_application_cohort: cohort,
-      city: Faker::Address.city,
-      state: Faker::Address.state,
-      country: Faker::Address.country,
-      reason_for_applying: Faker::Lorem.paragraph,
-      linkedin_url: Faker::Internet.url,
-      github_url: Faker::Internet.url,
+      linkedin_url: "https://linkedin.com/in/#{Faker::Internet.name}",
+      github_url: "https://github.com/#{Faker::Internet.name}",
       learned_to_code: Faker::Lorem.paragraph,
       project_experience: Faker::Lorem.paragraph,
       available_hours_per_week: 10,
       referral_source: Faker::Lorem.paragraph,
       additional_information: Faker::Lorem.paragraph
     }
-  ]
+  end
 
   UserMenteeApplication.transaction do
     user_mentee_application_data.each do |data|
       UserMenteeApplication.create!(data)
     end
   end
-
 rescue StandardError => e
   puts "Error occurred while seeding: #{e.message}"
   puts e.backtrace.join("\n")

--- a/lib/tasks/reapplication_notification_task.rake
+++ b/lib/tasks/reapplication_notification_task.rake
@@ -1,0 +1,20 @@
+class NoActiveCohortError < StandardError; end
+
+task enqueue_reapplication_notifications: :environment do
+  active_cohort = UserMenteeApplicationCohort.active
+  raise NoActiveCohortError if active_cohort.blank?
+
+  # Currently, looking at last 2 inactive cohorts
+  previous_cohorts_to_cull = UserMenteeApplicationCohort.inactive.last(2).pluck(:id)
+  # Gather users from previous cohort cycles who are still applicants
+  users = UserMenteeApplication.includes(:user).where(
+    user_mentee_application_cohort_id: previous_cohorts_to_cull,
+    user: { role: User.roles[:applicant] }
+  ).map(&:user)
+
+  users.each do |user|
+    MenteeApplication::ReapplicationNotification.with(active_cohort_name: active_cohort.name)
+                                                .deliver(user)
+    puts "Reapplication Notification enqueued for: #{user.full_name}"
+  end
+end

--- a/spec/mailers/mentee_application_mailer_spec.rb
+++ b/spec/mailers/mentee_application_mailer_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe MenteeApplicationMailer do
     it 'renders the headers' do
       expect(mail.subject).to eq('Invitation to Apply to the Agency of Learning')
       expect(mail.to).to eq([recipient.email])
-      expect(mail.from).to eq(['no_reply@agencyoflearning.com'])
+      expect(mail.from).to eq(['dave@agencyoflearning.com'])
     end
   end
 end

--- a/spec/mailers/mentee_application_mailer_spec.rb
+++ b/spec/mailers/mentee_application_mailer_spec.rb
@@ -53,14 +53,4 @@ RSpec.describe MenteeApplicationMailer do
       expect(mail.from).to eq(['dave@agencyoflearning.com'])
     end
   end
-
-  describe '#notify_for_reapplication' do
-    subject(:mail) { described_class.with(recipient:, active_cohort_name: 'Fall 2023').notify_for_reapplication }
-
-    it 'renders the headers' do
-      expect(mail.subject).to eq('Invitation to Apply to the Agency of Learning')
-      expect(mail.to).to eq([recipient.email])
-      expect(mail.from).to eq(['no_reply@agencyoflearning.com'])
-    end
-  end
 end

--- a/spec/mailers/mentee_application_mailer_spec.rb
+++ b/spec/mailers/mentee_application_mailer_spec.rb
@@ -43,4 +43,14 @@ RSpec.describe MenteeApplicationMailer do
       expect(mail.from).to eq(['dave@agencyoflearning.com'])
     end
   end
+
+  describe '#notify_for_reapplication' do
+    subject(:mail) { described_class.with(recipient:, active_cohort_name: 'Fall 2023').notify_for_reapplication }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Invitation to Apply to the Agency of Learning')
+      expect(mail.to).to eq([recipient.email])
+      expect(mail.from).to eq(['no_reply@agencyoflearning.com'])
+    end
+  end
 end

--- a/spec/mailers/mentee_application_mailer_spec.rb
+++ b/spec/mailers/mentee_application_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MenteeApplicationMailer do
     it 'renders the headers' do
       expect(mail.subject).to eq('Welcome to the Agency of Learning!')
       expect(mail.to).to eq([recipient.email])
-      expect(mail.from).to eq(['no_reply@agencyoflearning.com'])
+      expect(mail.from).to eq(['dave@agencyoflearning.com'])
     end
   end
 
@@ -20,7 +20,7 @@ RSpec.describe MenteeApplicationMailer do
     it 'renders the headers' do
       expect(mail.subject).to eq('Update on your application to the Agency of Learning')
       expect(mail.to).to eq([recipient.email])
-      expect(mail.from).to eq(['no_reply@agencyoflearning.com'])
+      expect(mail.from).to eq(['dave@agencyoflearning.com'])
     end
   end
 
@@ -30,7 +30,7 @@ RSpec.describe MenteeApplicationMailer do
     it 'renders the headers' do
       expect(mail.subject).to eq('Moving forward in the application process for the Agency of Learning')
       expect(mail.to).to eq([recipient.email])
-      expect(mail.from).to eq(['no_reply@agencyoflearning.com'])
+      expect(mail.from).to eq(['dave@agencyoflearning.com'])
     end
   end
 
@@ -40,7 +40,7 @@ RSpec.describe MenteeApplicationMailer do
     it 'renders the headers' do
       expect(mail.subject).to eq('Moving forward in the application process for the Agency of Learning')
       expect(mail.to).to eq([recipient.email])
-      expect(mail.from).to eq(['no_reply@agencyoflearning.com'])
+      expect(mail.from).to eq(['dave@agencyoflearning.com'])
     end
   end
 end

--- a/spec/mailers/previews/mentee_application_mailer_preview.rb
+++ b/spec/mailers/previews/mentee_application_mailer_preview.rb
@@ -16,4 +16,9 @@ class MenteeApplicationMailerPreview < ActionMailer::Preview
   def notify_for_code_challenge_approved
     MenteeApplicationMailer.with(recipient: User.last).notify_for_code_challenge_approved
   end
+
+  def notify_for_reapplication
+    MenteeApplicationMailer.with(recipient: User.last,
+      active_cohort_name: UserMenteeApplicationCohort.active.name).notify_for_reapplication
+  end
 end

--- a/spec/mailers/user_mentee_application_spec.rb
+++ b/spec/mailers/user_mentee_application_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe UserMenteeApplicationMailer do
     it 'renders the headers' do
       expect(mail.subject).to eq('Woohoo! Your Application’s In - Agency of Learning.')
       expect(mail.to).to eq([recipient.email])
-      expect(mail.from).to eq(['no_reply@agencyoflearning.com'])
+      expect(mail.from).to eq(['dave@agencyoflearning.com'])
     end
   end
 end


### PR DESCRIPTION
## What's the change?
Refactor seeds file to make it a smaller lift to generate more users, pair requests, cohorts, etc.
Generate mailer, mailer preview, and notification for reapplication email.
Generate reusable rake task to send notifications to previous applicants.

## What key workflows are impacted?
Method to notify previous applicants that they can reapply

## Highlights / Surprises / Risks / Cleanup
I generated more applicants and assigned half of them to the active cohort and half to the inactive cohort to make it a bit easier to confirm that it only goes out to some of the individuals with an applicant status.

Rake task enforces that an active cohort exists before sending out the mailers. Something to note -- the mailer will rely on the cohort name, so we should name the cohorts descriptively.

To test, check out the branch. Reseed/reset your db, then run `rake seed_applicant_responses`. If you open your [letter opener](localhost:3000/letter_opener), you should see 12 emails have been sent out.

## Demo / Screenshots
<img width="1279" alt="Screen Shot 2023-09-22 at 5 00 13 PM" src="https://github.com/agency-of-learning/PairApp/assets/2447409/0b171a76-c171-49a1-93c9-5e6704e16310">

## Issue ticket number and link
Closes #322 

## Checklist before requesting a review

Please delete items that are not relevant.

- [x] Did you consider risks around security, performance, etc.?
- [X] Have you thought of misfiring code? e.g. too many loops, n+1, or how to handle nils?
- [X] Any validations to data needed?
- [X] Related to readability and consistency: Did you add comments and/or documentation? (README, Notion, etc.)
- [X] Did you include instructions for how to test in the ticket?
- [X] Did you add any relevant tags and decide if this PR is a Draft vs. Ready for Review?
- [X] Do you have a plan for how this change should be rolled back? (e.g., how do you deal with a migration rollback? Is your feature released behind a feature flag?)
