### PR TITLE
345 user mentee application notification email changes

### DIFF
--- a/app/mailers/mentee_application_mailer.rb
+++ b/app/mailers/mentee_application_mailer.rb
@@ -1,4 +1,6 @@
 class MenteeApplicationMailer < ApplicationMailer
+  default from: 'dave@agencyoflearning.com'
+
   def notify_for_acceptance
     @application = params[:application]
     mail(subject: 'Welcome to the Agency of Learning!')

--- a/app/mailers/user_mentee_application_mailer.rb
+++ b/app/mailers/user_mentee_application_mailer.rb
@@ -1,4 +1,6 @@
 class UserMenteeApplicationMailer < ApplicationMailer
+  default from: 'dave@agencyoflearning.com'
+
   def notify_for_application_submission
     @user_mentee_application = params[:user_mentee_application]
     mail(subject: 'Woohoo! Your Application’s In - Agency of Learning.')

--- a/app/views/user_mentee_application_mailer/notify_for_application_submission.html.erb
+++ b/app/views/user_mentee_application_mailer/notify_for_application_submission.html.erb
@@ -12,4 +12,4 @@
   <p>Best,<br>
   Your Friends at Agency of Learning</p>
 
-  <p>If you have any questions or concerns, feel free to reply to this email. David's here to help!</p>
+  <p>If you have any questions or concerns, feel free to reply to this email. Dave's here to help!</p>

--- a/app/views/user_mentee_application_mailer/notify_for_application_submission.html.erb
+++ b/app/views/user_mentee_application_mailer/notify_for_application_submission.html.erb
@@ -11,3 +11,5 @@
   
   <p>Best,<br>
   Your Friends at Agency of Learning</p>
+
+  <p>If you have any questions or concerns, feel free to reply to this email. David's here to help!</p>

--- a/spec/mailers/mentee_application_mailer_spec.rb
+++ b/spec/mailers/mentee_application_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MenteeApplicationMailer do
     it 'renders the headers' do
       expect(mail.subject).to eq('Welcome to the Agency of Learning!')
       expect(mail.to).to eq([recipient.email])
-      expect(mail.from).to eq(['no_reply@agencyoflearning.com'])
+      expect(mail.from).to eq(['dave@agencyoflearning.com'])
     end
   end
 
@@ -20,7 +20,7 @@ RSpec.describe MenteeApplicationMailer do
     it 'renders the headers' do
       expect(mail.subject).to eq('Update on your application to the Agency of Learning')
       expect(mail.to).to eq([recipient.email])
-      expect(mail.from).to eq(['no_reply@agencyoflearning.com'])
+      expect(mail.from).to eq(['dave@agencyoflearning.com'])
     end
   end
 
@@ -30,7 +30,7 @@ RSpec.describe MenteeApplicationMailer do
     it 'renders the headers' do
       expect(mail.subject).to eq('Moving forward in the application process for the Agency of Learning')
       expect(mail.to).to eq([recipient.email])
-      expect(mail.from).to eq(['no_reply@agencyoflearning.com'])
+      expect(mail.from).to eq(['dave@agencyoflearning.com'])
     end
   end
 
@@ -40,7 +40,7 @@ RSpec.describe MenteeApplicationMailer do
     it 'renders the headers' do
       expect(mail.subject).to eq('Moving forward in the application process for the Agency of Learning')
       expect(mail.to).to eq([recipient.email])
-      expect(mail.from).to eq(['no_reply@agencyoflearning.com'])
+      expect(mail.from).to eq(['dave@agencyoflearning.com'])
     end
   end
 end

--- a/spec/mailers/user_mentee_application_spec.rb
+++ b/spec/mailers/user_mentee_application_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe UserMenteeApplicationMailer do
     it 'renders the headers' do
       expect(mail.subject).to eq('Woohoo! Your Application’s In - Agency of Learning.')
       expect(mail.to).to eq([recipient.email])
-      expect(mail.from).to eq(['no_reply@agencyoflearning.com'])
+      expect(mail.from).to eq(['dave@agencyoflearning.com'])
     end
   end
 end


### PR DESCRIPTION
## What's the change?
Changes default from:  in UserMenteeApplicationMailer from do_not_reply to Dave's email. 
Adds text to the notify_for_application_submission template to make sure applicants know they are able to reply to the notice meail
## What key workflows are impacted?
- It allows applicants to reply to  application submission notice email

## Demo / Screenshots
![Screen Shot 2023-09-22 at 10 54 56 AM](https://github.com/agency-of-learning/PairApp/assets/16809030/2ec2046c-a21e-462b-845f-ba119a5b0f40)

## Issue ticket number and link
#345 
## Checklist before requesting a review

Please delete items that are not relevant.

- [ ] Did you add appropriate automated tests?
- [ ] Is there any linting that needs to be executed?
