### PR TITLE
Style password reset forms

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+end

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -9,7 +9,7 @@
       <%= f.label :password, "New password", class: "label label-text text-lg" %>
       <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: 'input input-bordered' %>
       <% if @minimum_password_length %>
-        <em><%= @minimum_password_length %> characters minimum</em>
+        <span class="italic"><%= @minimum_password_length %> characters minimum</span>
       <% end %>
     </div>
 

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -23,7 +23,7 @@
     </div>
   <% end %>
 
-  <div class="underline mt-2">
-    <%= render "devise/shared/links" %> 
+  <div class="underline flex flex-col gap-2">
+    <%= render "users/shared/links" %> 
   </div>
 </div>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -18,7 +18,7 @@
       <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'input input-bordered' %>
     </div>
 
-    <div class="mb-6">
+    <div class="form-control mb-6 sm:w-fit">
       <%= f.submit "Change my password", class: 'btn btn-primary' %>
     </div>
   <% end %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,25 +1,29 @@
-<h2>Change your password</h2>
+<h2 class="text-3xl text-center font-bold mb-2">Change your password</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+<div class="max-w-xl mx-auto px-4">
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+    <%= f.hidden_field :reset_password_token %>
 
-  <div class="form-control">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+    <div class="form-control mb-2">
+      <%= f.label :password, "New password", class: "label label-text text-lg" %>
+      <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: 'input input-bordered' %>
+      <% if @minimum_password_length %>
+        <em><%= @minimum_password_length %> characters minimum</em>
+      <% end %>
+    </div>
+
+    <div class="form-control mb-4">
+      <%= f.label :password_confirmation, "Confirm new password", class: "label label-text text-lg" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'input input-bordered' %>
+    </div>
+
+    <div class="mb-6">
+      <%= f.submit "Change my password", class: 'btn btn-primary' %>
+    </div>
+  <% end %>
+
+  <div class="underline mt-2">
+    <%= render "devise/shared/links" %> 
   </div>
-
-  <div class="form-control">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="form-control">
-    <%= f.submit "Change my password", class: 'btn btn-primary' %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -9,7 +9,7 @@
       <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'input input-bordered' %>
     </div>
 
-    <div>
+    <div class="form-control sm:w-fit">
       <%= f.submit "Send me reset password instructions", class: 'btn btn-primary mb-4' %>
     </div>
   <% end %>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -14,7 +14,7 @@
     </div>
   <% end %>
 
-  <div class="underline mt-2">
-    <%= render "devise/shared/links" %> 
+  <div class="underline flex flex-col gap-2">
+    <%= render "users/shared/links" %> 
   </div>
 </div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,21 +1,20 @@
+<h2 class="text-3xl text-center font-bold mb-2">Forgot Your Passowrd?</h2>
 
-<div class="container mx-auto max-w-lg">
-  <h2 class="text-2xl">Forgot your password?</h2>
-
-  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: 'mb-4' }) do |f| %>
+<div class="max-w-xl mx-auto px-4">
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
 
-    <div class="form-control">
-      <%= f.label :email, class: 'label label-text' %>
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'input input-outline' %>
+    <div class="form-control mb-4">
+      <%= f.label :email, class: 'label label-text text-lg' %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'input input-bordered' %>
     </div>
 
-    <div class="form-control mt-4">
-      <%= f.submit "Send me reset password instructions", class: 'btn btn-primary btn-outline' %>
+    <div>
+      <%= f.submit "Send me reset password instructions", class: 'btn btn-primary mb-4' %>
     </div>
   <% end %>
 
-  <span class="block mx-auto">
+  <div class="underline mt-2">
     <%= render "devise/shared/links" %> 
-  </span>
+  </div>
 </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,6 +1,6 @@
-<h1 class="text-3xl text-center font-bold">Sign up</h2>
+<h2 class="text-3xl text-center font-bold">Sign up</h2>
 
-<div class="container  max-w-xl mx-auto px-4">
+<div class="max-w-xl mx-auto px-4">
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
 

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,4 +1,3 @@
-
 <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: 'container max-w-md mx-auto' } ) do |f| %>
   <h2 class='text-3xl mb-4'>Log in</h2>
   <div class="form-control">
@@ -11,21 +10,25 @@
     <%= f.password_field :password, autocomplete: "current-password", class: 'input input-bordered' %>
   </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="form-control">
-      <label class="label cursor-pointer justify-start space-x-4 pt-4">
+  <div class="form-control flex flex-row items-center justify-between mb-2">
+    <% if devise_mapping.rememberable? %>
+      <label class="label cursor-pointer justify-start space-x-4">
         <%= f.label :remember_me, class: 'label label-text text-lg' %> 
         <%= f.check_box :remember_me, class: 'checkbox' %>
       </label>
-    </div>
-  <% end %>
-
-  <div class="form-control mb-8">
-    <%= render "devise/shared/links" %>
+    <% end %>
+    <% if devise_mapping.recoverable? %>
+      <div>
+        <%= link_to "Forgot your password?", new_password_path(resource_name), class: 'label label-text text-lg underline hover:no-underline' %>
+      </div>
+    <% end %>
   </div>
 
-  <div class="form-control">
+  <div class="form-control mb-4">
     <%= f.submit "Log in", class: 'btn btn-primary' %>
   </div>
-<% end %>
 
+  <div class="underline mt-2 flex gap-2 items-center">
+    <%= render "users/shared/links" %>
+  </div>
+<% end %>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,21 +1,21 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name), class: 'btn btn-primary' %><br />
+  <%= link_to "Log in", new_session_path(resource_name) %>
 <% end %>
 
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name), class: 'label label-text text-lg' %><br />
+<%- if controller_name != 'registrations' %>
+  <%= link_to "Sign Up", new_registration_path(resource_name) %>
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: 'label label-text text-lg' %><br />
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: 'label label-text text-lg' %>
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: 'label label-text text-lg' %><br />
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: 'label label-text text-lg' %>
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false }, class: 'label label-text text-lg' %><br />
+    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false }, class: 'label label-text text-lg' %>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: {
     invitations: 'users/invitations',
+    passwords: 'users/passwords',
     sessions: 'users/sessions',
     registrations: 'users/registrations'
   }


### PR DESCRIPTION
## What's the change?
- Style the form for requesting a password reset
- Style the form for resetting the password

## What key workflows are impacted?
Password Resets

## Highlights / Surprises / Risks / Cleanup
## Demo / Screenshots
#### Request Reset Form Desktop
![Selection_302](https://github.com/agency-of-learning/PairApp/assets/88392688/122dec2d-5650-47ec-97a3-6c277dd09fac)

#### Request Reset Form Mobile
![Selection_303](https://github.com/agency-of-learning/PairApp/assets/88392688/c2d6755e-8de8-4110-9736-7d637f3954a4)

#### Password Reset Form Desktop
![Selection_304](https://github.com/agency-of-learning/PairApp/assets/88392688/7023615b-8347-44dd-b907-442dcb310369)

#### Password Reset Form Mobile
![Selection_305](https://github.com/agency-of-learning/PairApp/assets/88392688/59d4916a-08d2-4f8e-a455-898906782d6f)

## Issue ticket number and link
Closes #335

## Checklist before requesting a review

Please delete items that are not relevant.

- [x] Did you include instructions for how to test in the ticket?
- [x] Did you add any relevant tags and decide if this PR is a Draft vs. Ready for Review?

To test this flow locally, make sure you're logged out. Click the 'Login' button in the navbar and then click the 'Forgot your password?' link. Enter a seed user's email address into the field and submit.

Then you can visit `localhost:3000/letter_opener` and you should see the email that the user would receive. Click on it and you'll be taken to the form for creating a new password.
