### PR TITLE
update resume service now creates and/or updates

### DIFF
--- a/app/services/resumes/update_service.rb
+++ b/app/services/resumes/update_service.rb
@@ -11,10 +11,10 @@ module Resumes
     def call!
       ActiveRecord::Base.transaction do
         # Guard against doing unnecessary work
-        next if user.current_resume.id == current_resume_id && attributes[:resume].nil?
+        next if user.current_resume&.id == current_resume_id && attributes[:resume].nil?
         # Updating the current resume is a two step process
         # First need to switch the current resume to false
-        user.current_resume.update!(current: false)
+        user.current_resume&.update!(current: false)
         # If the resume was directly uploaded, create a new resume
         if attributes[:resume]
           user.resumes.create!(attributes)

--- a/spec/services/resumes/update_service_spec.rb
+++ b/spec/services/resumes/update_service_spec.rb
@@ -51,6 +51,43 @@ RSpec.describe Resumes::UpdateService do
       end
     end
 
+    context 'when the user has no resumes and a new resume is uploaded' do
+      let(:params) do
+        ActionController::Parameters.new({
+          profile: {
+            resume: uploaded_resume_signed_id,
+            resume_name: 'Uploaded resume',
+            current_resume_id: nil
+          }
+        }).require(:profile).permit(:resume, :resume_name, :current_resume_id)
+      end
+
+      it 'updates the user with the new resume' do
+        command.call!
+        current_resume = user.reload.current_resume
+        expect(current_resume).to be_present
+        expect(current_resume.name).to eq('Uploaded resume')
+        expect(current_resume.current).to be(true)
+      end
+    end
+
+    context 'when the user has no resumes and is not uploaded' do
+      let(:params) do
+        ActionController::Parameters.new({
+          profile: {
+            resume: nil,
+            resume_name: '',
+            current_resume_id: nil
+          }
+        }).require(:profile).permit(:resume, :resume_name, :current_resume_id)
+      end
+
+      it 'does nothing' do
+        command.call!
+        expect(user.reload.current_resume).to be_nil
+      end
+    end
+
     context 'when a new resume is not uploaded but a different resume is selected as current' do
       let!(:existing_resume) { create(:resume, user:, current: false) }
       let!(:newer_resume) { create(:resume, user:) }


### PR DESCRIPTION
## What's the change?
Internal implementation of the update service no longer forces the assumption that current user has a resume in order to run the update service.

## What key workflows are impacted?
Profile updates are now fixed.

## Demo / Screenshots
Demo showcases first that a profile can get updated successfully without a resume being attached. Next, it showcases that it successfully updates with the profile attached.

[Edurrhaphy_Recording_2023_09_26-13_27.webm](https://github.com/agency-of-learning/PairApp/assets/2447409/15275d85-57cc-46d0-bbdb-1796cbc44553)

## Issue ticket number and link
Closes #357 .

## Checklist before requesting a review

Please delete items that are not relevant.

- [X] Did you add appropriate automated tests?
- [X] Did you consider risks around security, performance, etc.?
- [X] Have you thought of misfiring code? e.g. too many loops, n+1, or how to handle nils?