### PR TITLE
link pushed to environment variable

### DIFF
--- a/app/views/mentee_application_mailer/notify_for_acceptance.html.erb
+++ b/app/views/mentee_application_mailer/notify_for_acceptance.html.erb
@@ -13,7 +13,7 @@
     To get started, please:
     <ul>
       <li>Create a <a href="https://www.discord.com/">Discord account</a>, if you don't already have one</li>
-      <li>Join our discord channel here: <a href="https://discord.gg/bkpkhvjQCk">https://discord.gg/bkpkhvjQCk</a></li>
+      <li>Join our discord channel here: <a href="<%=ENV['JOIN_AOL_DISCORD_URL']%>"><%=ENV['JOIN_AOL_DISCORD_URL']%></a></li>
     </ul> 
   </p>
 <hr />


### PR DESCRIPTION
## What's the change?
Extracts the discord link to be a different permanent link, stored in an environment variable.
This value is now directly stored on heroku.

## Issue ticket number and link
closes #344 