### PR TITLE
Correct landing page path for guests to point to `root_path`

### DIFF
--- a/app/components/navigation/guest_component.rb
+++ b/app/components/navigation/guest_component.rb
@@ -4,7 +4,7 @@ class Navigation::GuestComponent < NavigationComponent
   private
 
   def home_path
-    landing_index_path
+    root_path
   end
 
   def primary_links


### PR DESCRIPTION
## What's the change?
Fix 'Home' link for guest users. Should direct to root path but was directing to the landing page path. This was causing styling issues because the current styles on that page rely on what the current path is.