### PR TITLE
#340, remove past applications heading when no applitions are present

### DIFF
--- a/app/controllers/user_mentee_applications_controller.rb
+++ b/app/controllers/user_mentee_applications_controller.rb
@@ -12,6 +12,7 @@ class UserMenteeApplicationsController < ApplicationController
                                   :mentee_application_states
                                 )
 
+    @user_past_applications = @user_mentee_applications.past
     @most_recent_application = @user_mentee_applications.first
   end
 

--- a/app/controllers/user_mentee_applications_controller.rb
+++ b/app/controllers/user_mentee_applications_controller.rb
@@ -4,7 +4,7 @@ class UserMenteeApplicationsController < ApplicationController
 
   def index
     authorize :user_only, :applicant?
-    @user_mentee_applications = current_user
+    user_mentee_applications = current_user
                                 .mentee_applications
                                 .order_newest_first
                                 .includes(
@@ -12,7 +12,10 @@ class UserMenteeApplicationsController < ApplicationController
                                   :mentee_application_states
                                 )
 
-    @most_recent_application = @user_mentee_applications.first
+    @user_past_applications = user_mentee_applications
+                                .reject { |application| application.active? && application.in_review? }
+
+    @most_recent_application = user_mentee_applications.first
   end
 
   def show

--- a/app/controllers/user_mentee_applications_controller.rb
+++ b/app/controllers/user_mentee_applications_controller.rb
@@ -12,7 +12,6 @@ class UserMenteeApplicationsController < ApplicationController
                                   :mentee_application_states
                                 )
 
-    @user_past_applications = @user_mentee_applications.past
     @most_recent_application = @user_mentee_applications.first
   end
 

--- a/app/controllers/user_mentee_applications_controller.rb
+++ b/app/controllers/user_mentee_applications_controller.rb
@@ -5,15 +5,15 @@ class UserMenteeApplicationsController < ApplicationController
   def index
     authorize :user_only, :applicant?
     user_mentee_applications = current_user
-                                .mentee_applications
-                                .order_newest_first
-                                .includes(
-                                  :user_mentee_application_cohort,
-                                  :mentee_application_states
-                                )
+                               .mentee_applications
+                               .order_newest_first
+                               .includes(
+                                 :user_mentee_application_cohort,
+                                 :mentee_application_states
+                               )
 
     @user_past_applications = user_mentee_applications
-                                .reject { |application| application.active? && application.in_review? }
+                              .reject { |application| application.active? && application.in_review? }
 
     @most_recent_application = user_mentee_applications.first
   end

--- a/app/models/user_mentee_application.rb
+++ b/app/models/user_mentee_application.rb
@@ -61,13 +61,6 @@ class UserMenteeApplication < ApplicationRecord
   delegate :current_resume, to: :user
 
   scope :order_newest_first, -> { order(created_at: :desc) }
-  scope :past, -> do
-    joins(:current_state, :user_mentee_application_cohort)
-    .where(
-      current_state: {status: [:accepted, :rejected]},
-      user_mentee_application_cohort: {active: false}
-    )
-  end
 
   def current_status
     status

--- a/app/models/user_mentee_application.rb
+++ b/app/models/user_mentee_application.rb
@@ -61,6 +61,13 @@ class UserMenteeApplication < ApplicationRecord
   delegate :current_resume, to: :user
 
   scope :order_newest_first, -> { order(created_at: :desc) }
+  scope :past, -> do
+    joins(:current_state, :user_mentee_application_cohort)
+    .where(
+      current_state: {status: [:accepted, :rejected]},
+      user_mentee_application_cohort: {active: false}
+    )
+  end
 
   def current_status
     status

--- a/app/models/user_mentee_application.rb
+++ b/app/models/user_mentee_application.rb
@@ -63,10 +63,10 @@ class UserMenteeApplication < ApplicationRecord
   scope :order_newest_first, -> { order(created_at: :desc) }
   scope :past, -> do
     joins(:current_state, :user_mentee_application_cohort)
-    .where(
-      current_state: {status: [:accepted, :rejected]},
-      user_mentee_application_cohort: {active: false}
-    )
+      .where(
+        current_state: { status: %i[accepted rejected] },
+        user_mentee_application_cohort: { active: false }
+      )
   end
 
   def current_status

--- a/app/models/user_mentee_application.rb
+++ b/app/models/user_mentee_application.rb
@@ -63,10 +63,10 @@ class UserMenteeApplication < ApplicationRecord
   scope :order_newest_first, -> { order(created_at: :desc) }
   scope :past, -> do
     joins(:current_state, :user_mentee_application_cohort)
-      .where(
-        current_state: { status: %i[accepted rejected] },
-        user_mentee_application_cohort: { active: false }
-      )
+    .where(
+      current_state: {status: [:accepted, :rejected]},
+      user_mentee_application_cohort: {active: false}
+    )
   end
 
   def current_status

--- a/app/views/user_mentee_applications/index.html.erb
+++ b/app/views/user_mentee_applications/index.html.erb
@@ -15,12 +15,14 @@
     <% end %>
 
 
-    <h2 class="text-xl font-bold mb-2">Past Applications</h2>
-    <ul>
-      <% @user_mentee_applications.each do |mentee_application| %>
-        <% next if mentee_application.active? && mentee_application.in_review? %>
-        <%= render UserMenteeApplication::ListItemComponent.new(mentee_application:) %>
-      <% end %>
-    </ul>
+    <% if @user_mentee_applications.size.positive? %>
+      <h2 class="text-xl font-bold mb-2">Past Applications</h2>
+      <ul>
+        <% @user_mentee_applications.each do |mentee_application| %>
+          <% next if mentee_application.active? && mentee_application.in_review? %>
+          <%= render UserMenteeApplication::ListItemComponent.new(mentee_application:) %>
+        <% end %>
+      </ul>
+    <% end %>
   </div>
 </div>

--- a/app/views/user_mentee_applications/index.html.erb
+++ b/app/views/user_mentee_applications/index.html.erb
@@ -15,10 +15,11 @@
     <% end %>
 
 
-    <% if @user_past_applications.present? %>
+    <% if @user_mentee_applications.present? %>
       <h2 class="text-xl font-bold mb-2">Past Applications</h2>
       <ul>
-        <% @user_past_applications.each do |mentee_application| %>
+        <% @user_mentee_applications.each do |mentee_application| %>
+          <% next if mentee_application.active? && mentee_application.in_review? %>
           <%= render UserMenteeApplication::ListItemComponent.new(mentee_application:) %>
         <% end %>
       </ul>

--- a/app/views/user_mentee_applications/index.html.erb
+++ b/app/views/user_mentee_applications/index.html.erb
@@ -15,7 +15,7 @@
     <% end %>
 
 
-    <% if @user_mentee_applications.size.positive? %>
+    <% if @user_mentee_applications.present? %>
       <h2 class="text-xl font-bold mb-2">Past Applications</h2>
       <ul>
         <% @user_mentee_applications.each do |mentee_application| %>

--- a/app/views/user_mentee_applications/index.html.erb
+++ b/app/views/user_mentee_applications/index.html.erb
@@ -15,11 +15,10 @@
     <% end %>
 
 
-    <% if @user_mentee_applications.present? %>
+    <% if @user_past_applications.present? %>
       <h2 class="text-xl font-bold mb-2">Past Applications</h2>
       <ul>
-        <% @user_mentee_applications.each do |mentee_application| %>
-          <% next if mentee_application.active? && mentee_application.in_review? %>
+        <% @user_past_applications.each do |mentee_application| %>
           <%= render UserMenteeApplication::ListItemComponent.new(mentee_application:) %>
         <% end %>
       </ul>


### PR DESCRIPTION
## What's the change?

- This PR adds the conditional rendering of the _Past Applications_ heading.
- Now we will only display the above-mentioned heading only when applications are present
- Otherwise we will hide it.

## What key workflows are impacted?

- index page for the `/user_mentee_applications`

## Highlights / Surprises / Risks / Cleanup

- N/A

## Demo / Screenshots
![image](https://github.com/agency-of-learning/PairApp/assets/59338032/864ca19a-e286-44a2-b3c1-04b283b2e78d)

## Issue ticket number and link
Resolves #340 
