### PR TITLE
#332, fixes social media links

### DIFF
--- a/app/views/user_mentee_applications/show.html.erb
+++ b/app/views/user_mentee_applications/show.html.erb
@@ -79,11 +79,11 @@
   <%= render UserMenteeApplication::SectionComponent.new(header_text: "Job Hunting Information") do %>
     <div class="flex flex-col">
       <label class='label label-text font-semibold'>LinkedIn URL:</label>
-      <p><%= @user_mentee_application.linkedin_url %></p>
+      <a href="<%= @user_mentee_application.linkedin_url %>" target="_blank"><%= @user_mentee_application.linkedin_url %></a>
     </div>
     <div class="flex flex-col">
       <label class='label label-text font-semibold'>GitHub URL:</label>
-      <p><%= @user_mentee_application.github_url %></p>
+      <a href="<%= @user_mentee_application.github_url %>" target="_blank"><%= @user_mentee_application.github_url %></a>
     </div>
     <% if @user_mentee_application.current_resume %>
       <div class="flex flex-col">


### PR DESCRIPTION
## What's the change?
### Issue
- We are using paragraph tags for the social media links, that's the reason they were not clickable
### Solution
- This PR replaces the paragraph tags with the anchor tags so that we are able to redirect to the social media links into the new tab

## What key workflows are impacted?
- User application's view page

## Highlights / Surprises / Risks / Cleanup
- N/A

## Demo / Screenshots
[Screencast from 09-28-2023 04:45:28 PM.webm](https://github.com/agency-of-learning/PairApp/assets/59338032/02e67881-6d06-4063-9ba3-e2270cd694b5)

I don't know why my mouse pointer is not showing in the video :sweat_smile:

## Issue ticket number and link
- Resolves #332 
