### PR TITLE
Persist select option when there are validation errors in mentee applications form

### DIFF
--- a/app/views/user_mentee_applications/new.html.erb
+++ b/app/views/user_mentee_applications/new.html.erb
@@ -18,7 +18,12 @@
     <%= render UserMenteeApplication::SectionComponent.new(header_text: 'Tell us about your interest in the Agency of Learning') do %>
       <div class="flex flex-col mb-5">
         <%= form.label :reason_for_applying, 'Why are you here?', class: 'label-text mb-1' %>
-        <%= form.select :reason_for_applying, options_for_select(UserMenteeApplicationsHelper::REASONS_FOR_APPLYING), {}, class: 'select select-bordered', required: true %>
+        <%= form.collection_select :reason_for_applying,
+          UserMenteeApplicationsHelper::REASONS_FOR_APPLYING, :itself, :itself,
+          {},
+          class: 'select select-bordered',
+          required: true
+        %>
       </div>
 
       <div class="flex flex-col form-control">


### PR DESCRIPTION
## What's the change?
Fixed select input on mentee application form so that the selected option persists when there's a backend validation error

## What key workflows are impacted?
Filling out mentee application

## Highlights / Surprises / Risks / Cleanup
## Demo / Screenshots

https://github.com/agency-of-learning/PairApp/assets/88392688/294a8f10-5560-4853-aa7f-371ba20e1f94

## Issue ticket number and link
Closes #330 

## Checklist before requesting a review

Please delete items that are not relevant.

- [x] Did you add any relevant tags and decide if this PR is a Draft vs. Ready for Review?
