### PR TITLE
Maintain input width with error wrapper

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -7,7 +7,7 @@
 @import 'direct_uploads';
 
 .field_with_errors {
-  @apply flex [&>input]:input-error;
+  @apply flex [&>input]:input-error [&>input]:w-full;
 }
 
 /* Tailwind Trix Editor */


### PR DESCRIPTION
## What's the change?
Inputs now use full width in error wrapper

## What key workflows are impacted?
Inputs when backend validation fails

## Highlights / Surprises / Risks / Cleanup
This is a small change with a bit of a large footprint. It affects the inputs of every form on the site when backend validation errors occur.

I have checked/confirmed that this change fixes the problem and works well with the following forms:
- Devise Registration and Login
- Profile Edit
- User Mentee Application New
- Blog New/Edit

Definitely let me know if you think something else should be checked. Standup Meetings don't have any backend validations save for the meeting date (which the user doesn't control on the front end form), so I figure they're not relevant for this. Feedback also lacks BE validations for its form fields.

## Demo / Screenshots
#### New Behavior
![Selection_321](https://github.com/agency-of-learning/PairApp/assets/88392688/ddcd4590-2015-4e82-a1d9-f184b4a95f7c)

#### Old Behavior
![Selection_322](https://github.com/agency-of-learning/PairApp/assets/88392688/4c42f5d3-bde8-44b1-877d-545168d9c943)

## Issue ticket number and link
Closes #331 

## Checklist before requesting a review

Please delete items that are not relevant.

- [x] Did you include instructions for how to test in the ticket?
- [x] Did you add any relevant tags and decide if this PR is a Draft vs. Ready for Review?
