### PR TITLE
#334, adds empty state for the pair requests table

### DIFF
--- a/app/views/pair_requests/index.html.erb
+++ b/app/views/pair_requests/index.html.erb
@@ -9,30 +9,32 @@
       <%= link_to 'Upcoming', pair_requests_path(filter: 'upcoming'), data: { turbo_action: 'advance' }, class:"tab tab-lifted #{'tab-active' if params[:filter] == 'upcoming' || params[:filter].nil? }" %>
       <%= link_to 'Past', pair_requests_path(filter: 'past'), data: { turbo_action: 'advance' }, class:"tab tab-lifted #{'tab-active' if params[:filter] == 'past'}"  %>
     </div>
-    <div class="table w-full border-2 border-neutral text-md md:text-base">
-      <div class="table-header-group">
-        <div class="table-row font-bold bg-primary divide-x-2 divide-neutral text-primary-content">
-          <%= render TableCellComponent.new(class_names: 'table-cell text-center') do %>
-            Partner
-          <% end %>
-          <%= render TableCellComponent.new(class_names: 'table-cell text-center') do %>
-            When
-          <% end %>
-          <%= render TableCellComponent.new(class_names: 'table-cell text-center') do %>
-            Status
-          <% end %>
-          <%= render TableCellComponent.new(class_names: 'hidden sm:table-cell text-center') do %>
-            Actions
+
+    <% if @pair_requests.present? %>
+      <div class="table w-full border-2 border-neutral text-md md:text-base">
+        <div class="table-header-group">
+          <div class="table-row font-bold bg-primary divide-x-2 divide-neutral text-primary-content">
+            <%= render TableCellComponent.new(class_names: 'table-cell text-center') do %>
+              Partner
+            <% end %>
+            <%= render TableCellComponent.new(class_names: 'table-cell text-center') do %>
+              When
+            <% end %>
+            <%= render TableCellComponent.new(class_names: 'table-cell text-center') do %>
+              Status
+            <% end %>
+            <%= render TableCellComponent.new(class_names: 'hidden sm:table-cell text-center') do %>
+              Actions
+            <% end %>
+          </div>
+        </div>
+        <div class="table-row-group" id='my-pair-requests'>
+          <% @pair_requests.each do |pair_request| %>
+            <%= render "table_row", pair_request: %>
           <% end %>
         </div>
       </div>
-      <div class="table-row-group" id='my-pair-requests'>
-      <% @pair_requests.each do |pair_request| %>
-        <%= render "table_row", pair_request: %>
-      <% end %>
-      </div>
-    </div>
-
+    <% end %>
   </div>
 
 <% end %>


### PR DESCRIPTION
## What's the change?
- This PR adds check for the `@pair_requests` presence to render the table 
## What key workflows are impacted?
- Pair Requests page
## Highlights / Surprises / Risks / Cleanup
- N/A
## Demo / Screenshots
[Screencast from 09-30-2023 12:09:16 AM.webm](https://github.com/agency-of-learning/PairApp/assets/59338032/464bc43d-a418-4890-a669-2b5bdbdcabc9)

## Issue ticket number and link
Resolves #334