### PR TITLE
Add application_received tab to user_mentee_application_cohorts

### DIFF
--- a/app/controllers/user_mentee_application_cohorts_controller.rb
+++ b/app/controllers/user_mentee_application_cohorts_controller.rb
@@ -21,7 +21,7 @@ class UserMenteeApplicationCohortsController < ApplicationController
     when 'accepted', 'rejected', 'application_received'
       applications.filter { |application| application.current_status == params[:filter] }
     else
-      applications.filter(&:in_review?)
+      applications.filter { |application| application.current_status == 'application_received'}
     end
   end
 end

--- a/app/controllers/user_mentee_application_cohorts_controller.rb
+++ b/app/controllers/user_mentee_application_cohorts_controller.rb
@@ -21,7 +21,7 @@ class UserMenteeApplicationCohortsController < ApplicationController
     when 'accepted', 'rejected', 'application_received'
       applications.filter { |application| application.current_status == params[:filter] }
     else
-      applications.filter { |application| application.current_status == 'application_received'}
+      applications.filter { |application| application.current_status == 'application_received' }
     end
   end
 end

--- a/app/controllers/user_mentee_application_cohorts_controller.rb
+++ b/app/controllers/user_mentee_application_cohorts_controller.rb
@@ -18,7 +18,7 @@ class UserMenteeApplicationCohortsController < ApplicationController
 
   def filter_applications(applications)
     case params[:filter]
-    when 'accepted', 'rejected'
+    when 'accepted', 'rejected', 'application_received'
       applications.filter { |application| application.current_status == params[:filter] }
     else
       applications.filter(&:in_review?)

--- a/app/views/user_mentee_application_cohorts/show.html.erb
+++ b/app/views/user_mentee_application_cohorts/show.html.erb
@@ -4,10 +4,10 @@
 
 <div class="p-2">
   <div class="tabs">
-    <%= link_to 'In Review', user_mentee_application_cohort_path(@cohort, filter: "in_review" ) , class:"tab tab-lifted #{'tab-active' if params[:filter] == 'in_review' || params[:filter].nil? } " %>
+    <%= link_to  "Received", user_mentee_application_cohort_path(@cohort, filter: "application_received" ), class:"tab tab-lifted #{'tab-active' if params[:filter] == 'application_received' || params[:filter].nil? }" %>
+    <%= link_to 'In Review', user_mentee_application_cohort_path(@cohort, filter: "in_review" ) , class:"tab tab-lifted #{'tab-active' if params[:filter] == 'in_review'  } " %>
     <%= link_to 'Accepted', user_mentee_application_cohort_path(@cohort, filter: "accepted") , class:"tab tab-lifted #{'tab-active' if params[:filter] == 'accepted'}" %>
     <%= link_to  "Rejected", user_mentee_application_cohort_path(@cohort, filter: "rejected" ), class:"tab tab-lifted #{'tab-active' if params[:filter] == 'rejected' }" %>
-    <%= link_to  "Received", user_mentee_application_cohort_path(@cohort, filter: "application_received" ), class:"tab tab-lifted #{'tab-active' if params[:filter] == 'application_received' }" %>
   </div>
   <div class="table w-full border-2 border-base-content text-md md:text-base">
     <div class="table-header-group">

--- a/app/views/user_mentee_application_cohorts/show.html.erb
+++ b/app/views/user_mentee_application_cohorts/show.html.erb
@@ -6,7 +6,8 @@
   <div class="tabs">
     <%= link_to 'In Review', user_mentee_application_cohort_path(@cohort, filter: "in_review" ) , class:"tab tab-lifted #{'tab-active' if params[:filter] == 'in_review' || params[:filter].nil? } " %>
     <%= link_to 'Accepted', user_mentee_application_cohort_path(@cohort, filter: "accepted") , class:"tab tab-lifted #{'tab-active' if params[:filter] == 'accepted'}" %>
-    <%= link_to  "rejected", user_mentee_application_cohort_path(@cohort, filter: "rejected" ), class:"tab tab-lifted #{'tab-active' if params[:filter] == 'rejected' }" %>
+    <%= link_to  "Rejected", user_mentee_application_cohort_path(@cohort, filter: "rejected" ), class:"tab tab-lifted #{'tab-active' if params[:filter] == 'rejected' }" %>
+    <%= link_to  "Received", user_mentee_application_cohort_path(@cohort, filter: "application_received" ), class:"tab tab-lifted #{'tab-active' if params[:filter] == 'application_received' }" %>
   </div>
   <div class="table w-full border-2 border-base-content text-md md:text-base">
     <div class="table-header-group">


### PR DESCRIPTION
## What's the change?
Adds a new tab filter to user_mentee_application_cohorts table for "application_received"
Refactors filter_applications method to implement application_received filter
## What key workflows are impacted?
Allows admins to filter applications by "application_received"
## Highlights / Surprises / Risks / Cleanup
Currently we have the in_review filter to render all applications except applications that have not been accepted or rejected, should it include the  application_received too?
## Demo / Screenshots


https://github.com/agency-of-learning/PairApp/assets/16809030/8de566d5-d906-4ca2-84d3-3122b558f282


## Issue ticket number and link
#382 
## Checklist before requesting a review

Please delete items that are not relevant.
- [ ] Is there any linting that needs to be executed?
- [ ] Did you leave helpful inline PR comments for the reviewer(s)?
- [ ] Did you add any relevant tags and decide if this PR is a Draft vs. Ready for Review?

