### PR TITLE
Add mentee application state for withdrawing an application

### DIFF
--- a/app/controllers/user_mentee_application_cohorts_controller.rb
+++ b/app/controllers/user_mentee_application_cohorts_controller.rb
@@ -18,7 +18,7 @@ class UserMenteeApplicationCohortsController < ApplicationController
 
   def filter_applications(applications)
     case params[:filter]
-    when 'accepted', 'rejected', 'application_received'
+    when 'accepted', 'rejected', 'application_received', 'withdrawn'
       applications.filter { |application| application.current_status == params[:filter] }
     else
       applications.filter { |application| application.current_status == 'application_received' }

--- a/app/controllers/user_mentee_applications/withdrawals_controller.rb
+++ b/app/controllers/user_mentee_applications/withdrawals_controller.rb
@@ -1,0 +1,14 @@
+class UserMenteeApplications::WithdrawalsController < ApplicationController
+  def create
+    @user_mentee_application = UserMenteeApplication.find(params[:user_mentee_application_id])
+    authorize :user_only, :application_reviewer?
+
+    MenteeApplicationTransitionService.call(
+      application: @user_mentee_application,
+      reviewer: current_user,
+      action: :withdrawn
+    )
+
+    redirect_to @user_mentee_application, notice: 'Application withdrawn'
+  end
+end

--- a/app/mailers/mentee_application_mailer.rb
+++ b/app/mailers/mentee_application_mailer.rb
@@ -36,4 +36,8 @@ class MenteeApplicationMailer < ApplicationMailer
     @active_cohort_name = params[:active_cohort_name]
     mail(subject: 'Invitation to Apply to the Agency of Learning')
   end
+
+  def notify_applicant_of_withdrawal
+    mail(subject: 'Withdrawn application for the Agency of Learning')
+  end
 end

--- a/app/models/mentee_application_state.rb
+++ b/app/models/mentee_application_state.rb
@@ -34,7 +34,8 @@ class MenteeApplicationState < ApplicationRecord
     phone_screen_scheduled: 4,
     phone_screen_completed: 5,
     accepted: 6,
-    rejected: 7
+    rejected: 7,
+    withdrawn: 8
   }
 
   def valid_transitions

--- a/app/models/user_mentee_application.rb
+++ b/app/models/user_mentee_application.rb
@@ -71,7 +71,7 @@ class UserMenteeApplication < ApplicationRecord
   end
 
   def in_review?
-    !accepted? && !rejected?
+    %w[accepted rejected withdrawn].none?(current_status)
   end
 
   private

--- a/app/notifications/mentee_application/withdrawal_notification.rb
+++ b/app/notifications/mentee_application/withdrawal_notification.rb
@@ -1,0 +1,6 @@
+class MenteeApplication::WithdrawalNotification < Noticed::Base
+  deliver_by :email,
+    mailer: 'MenteeApplicationMailer',
+    method: :notify_applicant_of_withdrawal,
+    enqueue: true
+end

--- a/app/views/mentee_application_mailer/notify_applicant_of_withdrawal.html.erb
+++ b/app/views/mentee_application_mailer/notify_applicant_of_withdrawal.html.erb
@@ -1,0 +1,7 @@
+<div style='display: block; max-width: 36rem; margin: 0 auto; padding-top: 4rem;'>
+  <p>Hey <%= @recipient.full_name %>,</p>
+
+  <p>Your application for the Agency of Learning has been withdrawn.</p>
+
+  <p>We thank you for your interest in the Agency of Learning and encourage you to reapply in the future.</p>
+</div>

--- a/app/views/user_mentee_application_cohorts/show.html.erb
+++ b/app/views/user_mentee_application_cohorts/show.html.erb
@@ -8,6 +8,7 @@
     <%= link_to 'In Review', user_mentee_application_cohort_path(@cohort, filter: "in_review" ) , class:"tab tab-lifted #{'tab-active' if params[:filter] == 'in_review'  } " %>
     <%= link_to 'Accepted', user_mentee_application_cohort_path(@cohort, filter: "accepted") , class:"tab tab-lifted #{'tab-active' if params[:filter] == 'accepted'}" %>
     <%= link_to  "Rejected", user_mentee_application_cohort_path(@cohort, filter: "rejected" ), class:"tab tab-lifted #{'tab-active' if params[:filter] == 'rejected' }" %>
+    <%= link_to  "Withdrawn", user_mentee_application_cohort_path(@cohort, filter: "withdrawn" ), class:"tab tab-lifted #{'tab-active' if params[:filter] == 'withdrawn' }" %>
   </div>
   <div class="table w-full border-2 border-base-content text-md md:text-base">
     <div class="table-header-group">

--- a/app/views/user_mentee_applications/show.html.erb
+++ b/app/views/user_mentee_applications/show.html.erb
@@ -36,6 +36,15 @@
         <% end %>
       <% end %>
     </span>
+    <% if policy(:user_only).application_reviewer? && @user_mentee_application.in_review? %>
+      <span class="pb-4 inline mx-auto">
+        <%= button_to "Withdraw Application",
+          user_mentee_application_withdrawals_path(@user_mentee_application),
+          class: 'link link-error',
+          data: { turbo_confirm: 'Are you sure you want to withdraw this application?' }
+        %>
+      </span>
+    <% end %>
   </section>
 
   <%= render UserMenteeApplication::SectionComponent.new(header_text: "Tell us about your journey") do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
   resources :user_mentee_applications, only: %i[index show new create edit update] do
     scope module: :user_mentee_applications do
       resources :mentee_application_states, only: %i[new create]
+      resources :withdrawals, only: :create
     end
   end
 

--- a/spec/factories/user_mentee_applications.rb
+++ b/spec/factories/user_mentee_applications.rb
@@ -99,5 +99,11 @@ FactoryBot.define do
         create(:mentee_application_state, :rejected, user_mentee_application:)
       end
     end
+
+    trait :withdrawn do
+      after(:create) do |user_mentee_application|
+        create(:mentee_application_state, :rejected, user_mentee_application:)
+      end
+    end
   end
 end

--- a/spec/mailers/mentee_application_mailer_spec.rb
+++ b/spec/mailers/mentee_application_mailer_spec.rb
@@ -83,4 +83,17 @@ RSpec.describe MenteeApplicationMailer do
       expect(mail.bcc).to eq(['dave@agencyoflearning.com'])
     end
   end
+
+  describe '#notify_applicant_of_withdrawal' do
+    subject(:mail) do
+      described_class.with(application:, recipient:).notify_applicant_of_withdrawal
+    end
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Withdrawn application for the Agency of Learning')
+      expect(mail.to).to eq([recipient.email])
+      expect(mail.from).to eq(['dave@agencyoflearning.com'])
+      expect(mail.bcc).to eq(['dave@agencyoflearning.com'])
+    end
+  end
 end

--- a/spec/mailers/previews/mentee_application_mailer_preview.rb
+++ b/spec/mailers/previews/mentee_application_mailer_preview.rb
@@ -31,4 +31,8 @@ class MenteeApplicationMailerPreview < ActionMailer::Preview
     MenteeApplicationMailer.with(recipient: User.last,
       active_cohort_name: UserMenteeApplicationCohort.active.name).notify_applicant_to_reapply
   end
+
+  def notify_applicant_of_withdrawal
+    MenteeApplicationMailer.with(recipient: User.last).notify_applicant_of_withdrawal
+  end
 end

--- a/spec/models/user_mentee_application_spec.rb
+++ b/spec/models/user_mentee_application_spec.rb
@@ -86,6 +86,14 @@ RSpec.describe UserMenteeApplication do
       end
     end
 
+    context 'when the status is withdrawn' do
+      let(:status) { :withdrawn }
+
+      it 'is not in review' do
+        expect(mentee_application).not_to be_in_review
+      end
+    end
+
     context 'when the status is not rejected or accepted' do
       let(:status) { :application_received }
 

--- a/spec/services/mentee_application_transition_service_spec.rb
+++ b/spec/services/mentee_application_transition_service_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe MenteeApplicationTransitionService do
   let(:coding_challenge_approved) { create(:user_mentee_application, :coding_challenge_approved, user:) }
   let(:phone_screen_scheduled) { create(:user_mentee_application, :phone_screen_scheduled, user:) }
   let(:phone_screen_completed) { create(:user_mentee_application, :phone_screen_completed, user:) }
+  let(:withdrawn) { create(:user_mentee_application, :withdrawn, user:) }
   let(:accepted) { create(:user_mentee_application, :accepted, user:) }
   let(:rejected) { create(:user_mentee_application, :rejected, user:) }
 
@@ -108,6 +109,14 @@ RSpec.describe MenteeApplicationTransitionService do
       end
 
       context 'when the application has been rejected' do
+        it 'raises an invalid transition error' do
+          expect {
+            described_class.call(application: rejected, reviewer:, action:)
+          }.to raise_error MenteeApplicationTransitionService::InvalidTransitionError
+        end
+      end
+
+      context 'when the application has been withdrawn' do
         it 'raises an invalid transition error' do
           expect {
             described_class.call(application: rejected, reviewer:, action:)
@@ -319,6 +328,14 @@ RSpec.describe MenteeApplicationTransitionService do
         it 'raises an invalid transition error' do
           expect {
             described_class.call(application: rejected, reviewer:, action:)
+          }.to raise_error MenteeApplicationTransitionService::InvalidTransitionError
+        end
+      end
+
+      context 'when the application has been withdrawn' do
+        it 'raises an invalid transition error' do
+          expect {
+            described_class.call(application: withdrawn, reviewer:, action:)
           }.to raise_error MenteeApplicationTransitionService::InvalidTransitionError
         end
       end

--- a/spec/services/mentee_application_transition_service_spec.rb
+++ b/spec/services/mentee_application_transition_service_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe MenteeApplicationTransitionService do
       context 'when the application has been withdrawn' do
         it 'raises an invalid transition error' do
           expect {
-            described_class.call(application: rejected, reviewer:, action:)
+            described_class.call(application: withdrawn, reviewer:, action:)
           }.to raise_error MenteeApplicationTransitionService::InvalidTransitionError
         end
       end

--- a/spec/services/mentee_application_transition_service_spec.rb
+++ b/spec/services/mentee_application_transition_service_spec.rb
@@ -207,6 +207,122 @@ RSpec.describe MenteeApplicationTransitionService do
         end
       end
     end
+
+    context 'when the action is withdrawn' do
+      let(:action) { :withdrawn }
+
+      context 'when the application has been received' do
+        it 'withdraws the application' do
+          expect {
+            described_class.call(application: application_received, reviewer:, action:)
+          }.to change {
+            application_received.reload.current_status
+          }.from('application_received').to('withdrawn')
+        end
+
+        it 'enqueues a withdrawal mailer' do
+          expect {
+            described_class.call(application: application_received, reviewer:, action:)
+          }.to have_enqueued_mail(MenteeApplicationMailer, :notify_applicant_of_withdrawal)
+        end
+      end
+
+      context 'when the coding challenge has been sent' do
+        it 'withdraws the application' do
+          expect {
+            described_class.call(application: coding_challenge_sent, reviewer:, action:)
+          }.to change {
+            coding_challenge_sent.reload.current_status
+          }.from('coding_challenge_sent').to('withdrawn')
+        end
+
+        it 'enqueues a withdrawal mailer' do
+          expect {
+            described_class.call(application: coding_challenge_sent, reviewer:, action:)
+          }.to have_enqueued_mail(MenteeApplicationMailer, :notify_applicant_of_withdrawal)
+        end
+      end
+
+      context 'when the coding challenge has been received' do
+        it 'withdraws the application' do
+          expect {
+            described_class.call(application: coding_challenge_received, reviewer:, action:)
+          }.to change {
+            coding_challenge_received.reload.current_status
+          }.from('coding_challenge_received').to('withdrawn')
+        end
+
+        it 'enqueues a withdrawal mailer' do
+          expect {
+            described_class.call(application: coding_challenge_received, reviewer:, action:)
+          }.to have_enqueued_mail(MenteeApplicationMailer, :notify_applicant_of_withdrawal)
+        end
+      end
+
+      context 'when the coding challenge has been approved' do
+        it 'withdraws the application' do
+          expect {
+            described_class.call(application: coding_challenge_approved, reviewer:, action:)
+          }.to change {
+            coding_challenge_approved.reload.current_status
+          }.from('coding_challenge_approved').to('withdrawn')
+        end
+
+        it 'enqueues a withdrawal mailer' do
+          expect {
+            described_class.call(application: coding_challenge_approved, reviewer:, action:)
+          }.to have_enqueued_mail(MenteeApplicationMailer, :notify_applicant_of_withdrawal)
+        end
+      end
+
+      context 'when the phone screen has been scheduled' do
+        it 'withdraws the application' do
+          expect {
+            described_class.call(application: phone_screen_scheduled, reviewer:, action:)
+          }.to change {
+            phone_screen_scheduled.reload.current_status
+          }.from('phone_screen_scheduled').to('withdrawn')
+        end
+
+        it 'enqueues a withdrawal mailer' do
+          expect {
+            described_class.call(application: phone_screen_scheduled, reviewer:, action:)
+          }.to have_enqueued_mail(MenteeApplicationMailer, :notify_applicant_of_withdrawal)
+        end
+      end
+
+      context 'when the phone screen has been completed' do
+        it 'withdraws the application' do
+          expect {
+            described_class.call(application: phone_screen_completed, reviewer:, action:)
+          }.to change {
+            phone_screen_completed.reload.current_status
+          }.from('phone_screen_completed').to('withdrawn')
+        end
+
+        it 'enqueues a withdrawal mailer' do
+          expect {
+            described_class.call(application: phone_screen_completed, reviewer:, action:)
+          }.to have_enqueued_mail(MenteeApplicationMailer, :notify_applicant_of_withdrawal)
+        end
+      end
+
+      context 'when the application has been accepted' do
+        it 'raises an invalid transition error' do
+          expect {
+            described_class.call(application: accepted, reviewer:, action:)
+          }.to raise_error MenteeApplicationTransitionService::InvalidTransitionError
+        end
+      end
+
+      context 'when the application has been rejected' do
+        it 'raises an invalid transition error' do
+          expect {
+            described_class.call(application: rejected, reviewer:, action:)
+          }.to raise_error MenteeApplicationTransitionService::InvalidTransitionError
+        end
+      end
+    end
   end
 
   describe '.valid_transitions' do


### PR DESCRIPTION
## What's the change?
- Add `withdrawn` status to `MenteeApplicationStates` model
- Allow the application state transition service to handle applications that are transitioned to "withdrawal"
- Add mailer and notification for withdrawn applications
- Add interface for withdrawing an application

## What key workflows are impacted?
Working with applications. New ability to mark an application as "withdrawn"

## Highlights / Surprises / Risks / Cleanup
## Demo / Screenshots
![Selection_325](https://github.com/agency-of-learning/PairApp/assets/88392688/4c91bbec-2ca4-4aef-982a-b86daf4bf61f)

## Issue ticket number and link
Closes #390 

## Checklist before requesting a review

Please delete items that are not relevant.

- [x] Did you add appropriate automated tests?
- [x] Did you leave helpful inline PR comments for the reviewer(s)?
- [x] Did you add any relevant tags and decide if this PR is a Draft vs. Ready for Review?

## Questions:

Marking this as draft and have a few of questions I'd like answered before full review / merge
1. How's the copy on the withdrawal mailer? I kept it pretty light, not sure if we want to say more or if this is fine.
2. Do we want to introduce a new tab on the index table for withdrawn applications? Or combine them with rejected maybe? The current implementation currently doesn't display them at all, which is probably not what we want.
3. Do we want to allow applicants the opportunity to directly interact with this? To me, there's maybe no reason why an applicant couldn't be able to just directly withdraw from the process without having to email the agency and ask for it. The current implementation only allows application reviewers (mods and admins) to withdraw an application.
