### PR TITLE
Add missed standup meeting job

### DIFF
--- a/app/workers/standup_meeting/auto_missed_meeting_worker.rb
+++ b/app/workers/standup_meeting/auto_missed_meeting_worker.rb
@@ -1,0 +1,14 @@
+class StandupMeeting
+  class AutoMissedMeetingWorker < ApplicationWorker
+    sidekiq_options queue: 'low'
+
+    # rubocop:disable Rails/SkipsModelValidations
+    def perform
+      StandupMeeting
+        .draft
+        .where(meeting_date: ...1.week.ago)
+        .update_all(status: :missed)
+    end
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end

--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -17,3 +17,7 @@ end
 s.every '15m' do
   StandupMeetingGroup::DetermineMissingStandupMeetingsWorker.perform_async(0, 60)
 end
+
+s.every '24h' do
+  StandupMeeting::AutoMissedMeetingWorker.perform_async
+end

--- a/spec/workers/standup_meeting/auto_missed_meeting_worker_spec.rb
+++ b/spec/workers/standup_meeting/auto_missed_meeting_worker_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe StandupMeeting::AutoMissedMeetingWorker do
     end
 
     it "changes the status to 'missed' for old draft meetings" do
-      described_class.new.perform
       old_draft_meeting.reload
       expect(old_draft_meeting.status).to eq 'missed'
     end

--- a/spec/workers/standup_meeting/auto_missed_meeting_worker_spec.rb
+++ b/spec/workers/standup_meeting/auto_missed_meeting_worker_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe StandupMeeting::AutoMissedMeetingWorker do
+  context 'when the meeting is a draft meeting' do
+    let!(:new_draft_meeting) { create(:standup_meeting) }
+    let!(:old_draft_meeting) { create(:standup_meeting, meeting_date: 8.days.ago) }
+
+    before do
+      described_class.new.perform
+    end
+
+    it 'does not change the status for new draft meetings' do
+      new_draft_meeting.reload
+      expect(new_draft_meeting.status).to eq 'draft'
+    end
+
+    it "changes the status to 'missed' for old draft meetings" do
+      described_class.new.perform
+      old_draft_meeting.reload
+      expect(old_draft_meeting.status).to eq 'missed'
+    end
+  end
+
+  context 'when the meeting is not a draft meeting' do
+    let!(:old_completed_meeting) { create(:standup_meeting, meeting_date: 8.days.ago, status: :completed) }
+    let!(:old_skipped_meeting) { create(:standup_meeting, meeting_date: 8.days.ago, status: :skipped) }
+
+    before do
+      described_class.new.perform
+    end
+
+    it 'does not change the status for old completed meetings' do
+      old_completed_meeting.reload
+      expect(old_completed_meeting.status).to eq 'completed'
+    end
+
+    it 'does not change the status for old skipped meetings' do
+      old_skipped_meeting.reload
+      expect(old_skipped_meeting.status).to eq 'skipped'
+    end
+  end
+end


### PR DESCRIPTION
## What's the change?
Add worker for marking old draft meetings (older than 1 week) as `missed`.

This worker is also scheduled to run once per day. I figured it wasn't necessary to run it more frequently than this.

## What key workflows are impacted?
Standup meetings

## Highlights / Surprises / Risks / Cleanup
## Demo / Screenshots

## Issue ticket number and link
Closes #391 

## Checklist before requesting a review

Please delete items that are not relevant.

- [x] Did you add appropriate automated tests?
- [x] Did you consider risks around security, performance, etc.?
