### PR TITLE
Rename "members" scope to "agents"

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,7 +85,15 @@ class User < ApplicationRecord
 
   after_create :create_profile!
 
-  scope :members, -> { where(role: %i[member admin]) }
+  enum role: {
+    member: 0,
+    admin: 1,
+    applicant: 2,
+    moderator: 3
+  }
+  AGENT_ROLES = %w[member admin moderator].freeze
+
+  scope :agents, -> { where(role: AGENT_ROLES) }
   scope :super_admins, -> { where(email: ['daniel@agencyoflearning.com', 'dave@agencyoflearning.com']) }
 
   def self.invite!(attributes = {}, invited_by = nil, options = {}, &)
@@ -112,11 +120,4 @@ class User < ApplicationRecord
   def blog_slug
     profile.slug || profile.id
   end
-
-  enum role: {
-    member: 0,
-    admin: 1,
-    applicant: 2,
-    moderator: 3
-  }
 end

--- a/app/views/pair_requests/_form.html.erb
+++ b/app/views/pair_requests/_form.html.erb
@@ -4,7 +4,7 @@
       <div class="flex justify-between space-x-4 align-middle items-center ">
          <%= form.label :invitee_id, class: "label label-text" %>
          <%= form.select :invitee_id, nil, { :include_blank => "Please select" }, { class: "select select-primary", data: { action: "change->pair-requests-form#onClick", "pair-requests-form-target" => "inviteeInfo"}} do %>
-          <% User.members.excluding(current_user).each do |invitee| %>
+          <% User.agents.excluding(current_user).each do |invitee| %>
             <%= tag.option(invitee.full_name, value: invitee.id, data: { "time-zone-identifier" => invitee.time_zone_identifier, "time-zone-display-name" => invitee.time_zone, "user-time-zone" => current_user.time_zone_identifier}) %>
           <% end %>
         <% end %>


### PR DESCRIPTION
## What's the change?
- Rename `agents` scope to `members`
- Ensure "moderators" are part of the scope (they weren't before)

I'd originally thought about renaming the "member" role to "agent", but after some consideration, I think I like this more. The "member" role stays as is, and "agents" would be all users who are admins, moderators, or members (ie. people who have been accepted into the agency).

If this is a good route to take, a natural next step could be to create a new `UserOnly` policy method: `#agent?`. This can be used to authorize certain actions/routes that should be agent only. I didn't include all that in this PR just because I want to make sure people are on board with this name scheme before doing that work (also keeps this PR's scope small)

## What key workflows are impacted?
Not user facing

## Highlights / Surprises / Risks / Cleanup
## Demo / Screenshots

## Issue ticket number and link

## Checklist before requesting a review

Please delete items that are not relevant.

- [x] Did you add any relevant tags and decide if this PR is a Draft vs. Ready for Review?
