### PR TITLE
Add `agent?` policy method and lock down routes that should be agent only

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,8 @@ class ApplicationController < ActionController::Base
 
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  before_action :only_authorize_agent
+
   # PaperTrail helper for getting current_user
   before_action :set_paper_trail_whodunnit
 
@@ -40,5 +42,9 @@ class ApplicationController < ActionController::Base
 
     flash[:alert] = t "#{policy_name}.#{exception.query}", scope: 'pundit', default: :default
     redirect_back(fallback_location: root_path)
+  end
+
+  def only_authorize_agent
+    authorize :user_only, :agent?
   end
 end

--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -1,5 +1,6 @@
 class BlogPostsController < ApplicationController
   skip_before_action :authenticate_user!, only: :show
+  skip_before_action :only_authorize_agent, only: :show
 
   def index
     @blog_posts = BlogPost.includes(:user).published.order_newest_first

--- a/app/controllers/featured_blog_posts_controller.rb
+++ b/app/controllers/featured_blog_posts_controller.rb
@@ -1,5 +1,6 @@
 class FeaturedBlogPostsController < ApplicationController
   skip_before_action :authenticate_user!, only: :index
+  skip_before_action :only_authorize_agent, only: :index
 
   def index
     @featured_blog_posts = FeaturedBlogPost.in_rank_order.blog_posts

--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -1,5 +1,6 @@
 class LandingController < ApplicationController
   skip_before_action :authenticate_user!
+  skip_before_action :only_authorize_agent
 
   def index
     if current_user.blank?

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,4 +1,6 @@
 class StaticController < ApplicationController
   before_action :authenticate_user!, except: [:faq]
+  skip_before_action :only_authorize_agent, only: [:faq]
+
   def faq; end
 end

--- a/app/controllers/user_mentee_applications_controller.rb
+++ b/app/controllers/user_mentee_applications_controller.rb
@@ -1,6 +1,7 @@
 class UserMenteeApplicationsController < ApplicationController
   include ActiveStorage::SetCurrent
   before_action :set_active_cohort, only: %i[index new create]
+  skip_before_action :only_authorize_agent
 
   def index
     authorize :user_only, :applicant?

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Users::PasswordsController < Devise::PasswordsController
+  skip_before_action :only_authorize_agent
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+  skip_before_action :only_authorize_agent
+
   protected
 
   def after_sign_up_path_for(_resource)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
+  skip_before_action :only_authorize_agent
+
   protected
 
   def after_sign_in_path_for(user)

--- a/app/policies/user_only_policy.rb
+++ b/app/policies/user_only_policy.rb
@@ -1,6 +1,10 @@
 class UserOnlyPolicy < ApplicationPolicy
   attr_reader :user
 
+  def agent?
+    User::AGENT_ROLES.include?(user.role)
+  end
+
   # the delegate method forwards the admin? method call @user's admin? method
   delegate :admin?, :applicant?, to: :user
 end

--- a/app/policies/user_only_policy.rb
+++ b/app/policies/user_only_policy.rb
@@ -2,6 +2,8 @@ class UserOnlyPolicy < ApplicationPolicy
   attr_reader :user
 
   def agent?
+    return false if user.nil?
+
     User::AGENT_ROLES.include?(user.role)
   end
 

--- a/spec/policies/user_only_policy_spec.rb
+++ b/spec/policies/user_only_policy_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.describe UserOnlyPolicy, type: :policy do
   subject { described_class }
 
-  let(:member_user) { create(:user) }
-  let(:admin_user) { create(:user, :admin) }
-  let(:applicant_user) { create(:user, :applicant) }
-  let(:moderator_user) { create(:user, :moderator) }
+  let(:member_user) { build(:user) }
+  let(:admin_user) { build(:user, :admin) }
+  let(:applicant_user) { build(:user, :applicant) }
+  let(:moderator_user) { build(:user, :moderator) }
 
   permissions :admin? do
     it 'denies access if user is not admin' do
@@ -30,6 +30,24 @@ RSpec.describe UserOnlyPolicy, type: :policy do
 
     it 'denies access if user is a member' do
       expect(subject).not_to permit(member_user)
+    end
+
+    it 'denies access if user is an applicant' do
+      expect(subject).not_to permit(applicant_user)
+    end
+  end
+
+  permissions :agent? do
+    it 'grants access if the user is an admin' do
+      expect(subject).to permit(admin_user)
+    end
+
+    it 'grants access if the user is a moderator' do
+      expect(subject).to permit(moderator_user)
+    end
+
+    it 'grants access if user is a member' do
+      expect(subject).to permit(member_user)
     end
 
     it 'denies access if user is an applicant' do


### PR DESCRIPTION
## What's the change?
- In `UserOnlyPolicy`, `#agent?` method checks if a user is an agent of organization
- `ApplicationController` checks that the user is an agent before any actions
- Exceptions to this are specified for the following controllers:
  - `BlogPostsController#show`
  - `FeaturedBlogPostsController#index`
  - `LandingController`
  - `StaticController`
  - `UserMenteeApplicationsController`
  - Devise related controllers
 
## What key workflows are impacted?
Applicants (non-agents) can only access certain routes.

## Highlights / Surprises / Risks / Cleanup
n/a

## Demo / Screenshots
n/a

## Issue ticket number and link
Closes #413

## Checklist before requesting a review

- [x] Did you add appropriate automated tests?
- [x] Did you consider risks around security, performance, etc.?
- [x] Have you thought of misfiring code? e.g. too many loops, n+1, or how to handle nils?
