### PR TITLE
Add empty state to tables on Pair Requests

### DIFF
--- a/app/views/pair_requests/_empty_state.html.erb
+++ b/app/views/pair_requests/_empty_state.html.erb
@@ -1,4 +1,4 @@
-<div class="hero bg-base-200">
+<div class="hero bg-base-200 border-t-0 border-2 border-neutral">
     <div class="hero-content text-center">
     <div class="max-w-md">
         <h3 class="text-3xl font-bold">No Pair Requests</h1>

--- a/app/views/pair_requests/_empty_state.html.erb
+++ b/app/views/pair_requests/_empty_state.html.erb
@@ -1,0 +1,8 @@
+<div class="hero bg-base-200">
+    <div class="hero-content text-center">
+    <div class="max-w-md">
+        <h3 class="text-3xl font-bold">No Pair Requests</h1>
+        <p class="py-6"> You have no pair requests. Create one now!</p>
+    </div>
+    </div>
+</div>

--- a/app/views/pair_requests/index.html.erb
+++ b/app/views/pair_requests/index.html.erb
@@ -32,7 +32,9 @@
       <% end %>
       </div>
     </div>
-
+      <% if @pair_requests.empty? %>
+          <%= render 'empty_state' %>
+      <% end %>
   </div>
 
 <% end %>


### PR DESCRIPTION
## What's the change?

-  Adds empty state when there is no Pair Requests to show on the table list.

## What key workflows are impacted?
## Highlights / Surprises / Risks / Cleanup
## Demo / Screenshots
![image](https://github.com/agency-of-learning/PairApp/assets/85266997/228267d4-e86b-44e9-ba2b-b75e4297df44)

## Issue ticket number and link

#334 

## Checklist before requesting a review

- [x] Is there any linting that needs to be executed?
- [x] Did you add any relevant tags and decide if this PR is a Draft vs. Ready for Review?
