### PR TITLE
Prevent exception when creating standup group

### DIFF
--- a/app/views/standup_meeting_groups/create.turbo_stream.erb
+++ b/app/views/standup_meeting_groups/create.turbo_stream.erb
@@ -2,7 +2,7 @@
 
 <% if @standup_meeting_group.valid? %>
   <%= turbo_stream.prepend  "find-standup-meeting-groups" do %>
-    <%= render StandupMeetingGroup::JoinableItemComponent.new(standup_meeting_group: @standup_meeting_group, current_user: current_user) %>
+    <%= render StandupMeetingGroup::JoinableItemComponent.new(standup_meeting_group: @standup_meeting_group, my_standup_meeting_groups: @my_standup_meeting_groups, current_user: current_user) %>
   <% end %>
 
   <%= turbo_stream.update "new_standup_meeting_group"  do %>


### PR DESCRIPTION
## What's the change?

- Adds missing keyword arg to a ViewComponent.

## What key workflows are impacted?

- Creating standup groups.

## Highlights / Surprises / Risks / Cleanup

N/A

## Demo / Screenshots

N/A

## Issue ticket number and link

Closes #419 