### PR TITLE
Add information to sign up page when no cohort is active

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,6 +3,11 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   skip_before_action :only_authorize_agent
 
+  def new
+    @active_cohort_flag = UserMenteeApplicationCohort.active.present?
+    super
+  end
+
   protected
 
   def after_sign_up_path_for(_resource)

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,4 +1,18 @@
-<h2 class="text-3xl text-center font-bold">Sign up</h2>
+<h2 class="text-3xl text-center font-bold mb-4">Sign up</h2>
+
+<% unless @active_cohort_flag %>
+  <div class="px-2">
+    <div class="mx-auto flex max-w-xl gap-4 border-2 shadow-lg p-4 pr-8 mb-8">
+      <div>
+        <i class="fa-solid fa-circle-exclamation fa-2xl text-warning bg-warning-content rounded-full border-2 border-warning-content"></i>
+      </div>
+      <div class="flex-1 flex flex-col gap-2">
+        <p>Unfortunately, we are not currently accepting new applicants.</p>
+        <p>We still encourage you to sign up. We will contact you by email next time applications open up.</p>
+      </div>
+    </div>
+  </div>
+<% end %>
 
 <div class="max-w-xl mx-auto px-4">
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>


### PR DESCRIPTION
## What's the change?
- Change sign up page so that when no cohort is currently active, users know that they will have to wait to apply next time applications open up.

## What key workflows are impacted?
Signing up and applying

## Highlights / Surprises / Risks / Cleanup
## Demo / Screenshots
#### Mobile View
![image](https://github.com/agency-of-learning/PairApp/assets/88392688/6cbc0722-a6e8-428e-bdd1-f08a2ec37853)

#### Desktop View
![Selection_338](https://github.com/agency-of-learning/PairApp/assets/88392688/4bad8a93-ac77-4653-afaa-2b5a259baa83)

## Issue ticket number and link
Closes #427 

## Checklist before requesting a review

Please delete items that are not relevant.

- [x] Have you thought of misfiring code? e.g. too many loops, n+1, or how to handle nils?
- [x] Did you include instructions for how to test in the ticket?
- [x] Did you add any relevant tags and decide if this PR is a Draft vs. Ready for Review?

To test this ticket, open up an instance of the rails console and turn the currently active cohort to inactive.
```rb
cohort = UserMenteeApplicationCohort.active
cohort.active = false
cohort.save
```
Then if you try to sign in (click "Become Member" on the landing page), you should see the alert box with the information.