### PR TITLE
User Mentee Applications: add ability for admins to view all notes associated with status

### DIFF
--- a/app/components/user_mentee_application/notes_component.html.erb
+++ b/app/components/user_mentee_application/notes_component.html.erb
@@ -2,11 +2,4 @@
   <h3 class="text-lg font-semibold">Reviewer notes</h3>
 </div>
 
-<ul>
-  <% status_and_notes.map do |status, note| %>
-    <li class="mb-1">
-      <span class="font-semibold"><%= status %>: </span>
-      <%= note %>
-    </li>
-  <% end %>
-</ul>
+<%= select_tag "status", options_for_select(status_and_notes.keys, current_status), class: "select select-primary"%>

--- a/app/components/user_mentee_application/notes_component.html.erb
+++ b/app/components/user_mentee_application/notes_component.html.erb
@@ -1,0 +1,12 @@
+<div class="pb-5">
+  <h3 class="text-lg font-semibold">Reviewer notes</h3>
+</div>
+
+<ul>
+  <% status_and_notes.map do |status, note| %>
+    <li class="mb-1">
+      <span class="font-semibold"><%= status %>: </span>
+      <%= note %>
+    </li>
+  <% end %>
+</ul>

--- a/app/components/user_mentee_application/notes_component.html.erb
+++ b/app/components/user_mentee_application/notes_component.html.erb
@@ -1,5 +1,20 @@
-<div class="pb-5">
-  <h3 class="text-lg font-semibold">Reviewer notes</h3>
-</div>
 
-<%= select_tag "status", options_for_select(status_and_notes.keys, current_status), class: "select select-primary"%>
+<div class="text-md text-base-content/70 mb-3">Reviewer Notes</div>
+
+<div data-controller="select" data-select-notes-value="<%= status_and_notes.to_json %>">
+  <div>
+    <span class="mr-2">Status</span>
+    <%= select_tag "status",
+                    options_for_select(status_and_notes.keys, current_status),
+                    class: "select select-primary",
+                    data: { action:
+                      "change->select#onChange",
+                      "select-target" => "selectTag",
+                    } %>
+  </div>
+
+  <div class="flex gap-2 items-center mt-4">
+    <span class="mr-2">Note</span>
+    <p data-select-target="result" class="border-dotted border-2 rounded-md p-2"></p>
+  </div>
+</div>

--- a/app/components/user_mentee_application/notes_component.rb
+++ b/app/components/user_mentee_application/notes_component.rb
@@ -18,4 +18,8 @@ class UserMenteeApplication::NotesComponent < ViewComponent::Base
     end
     status_and_notes
   end
+
+  def current_status
+    @mentee_application.current_status.to_s.humanize
+  end
 end

--- a/app/components/user_mentee_application/notes_component.rb
+++ b/app/components/user_mentee_application/notes_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class UserMenteeApplication::NotesComponent < ViewComponent::Base
+  def initialize(mentee_application:)
+    @mentee_application = mentee_application
+  end
+
+  private
+
+  attr_reader :mentee_application
+
+  def status_and_notes
+    status_and_notes = {}
+    mentee_application.mentee_application_states.each do |state|
+      status = state.status.to_s.humanize
+      note = state.note || 'n/a'
+      status_and_notes[status] = note
+    end
+    status_and_notes
+  end
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,9 +10,9 @@ import ModalController from './modal_controller';
 
 import PairRequestsFormController from './pair_requests_form_controller';
 
-import RemovalController from './removal';
+import SelectController from './select_controller';
 
 application.register('link-builder', LinkBuilderController);
 application.register('modal', ModalController);
 application.register('pair-requests-form', PairRequestsFormController);
-application.register('removal', RemovalController);
+application.register('select', SelectController);

--- a/app/javascript/controllers/select_controller.js
+++ b/app/javascript/controllers/select_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from '@hotwired/stimulus';
+
+// Connects to data-controller="select"
+export default class extends Controller {
+  static targets = ['selectTag', 'result'];
+
+  static values = {
+    notes: Object,
+  };
+
+  connect() {
+    this.displayResult();
+  }
+
+  onChange() {
+    this.displayResult();
+  }
+
+  displayResult() {
+    const selectedStatus = this.selectTagTarget.value;
+    this.resultTarget.textContent = (`${this.notesValue[selectedStatus]}`);
+  }
+}

--- a/app/views/admin/user_mentee_applications/mentee_application_states/create.turbo_stream.erb
+++ b/app/views/admin/user_mentee_applications/mentee_application_states/create.turbo_stream.erb
@@ -10,7 +10,7 @@
 <% end %>
 
 <%= turbo_stream.update "#{dom_id(@user_mentee_application)}--note" do %>
-  <%= @user_mentee_application.current_state.note %>
+  <%= render UserMenteeApplication::NotesComponent.new(mentee_application: @user_mentee_application) %>
 <% end %>
 
 <%= turbo_stream.update "#{dom_id(@user_mentee_application)}--manage" do %>

--- a/app/views/admin/user_mentee_applications/show.html.erb
+++ b/app/views/admin/user_mentee_applications/show.html.erb
@@ -13,7 +13,9 @@
 
     <hr>
     <span class="p-4 inline mx-auto text-center">
-      <%= render UserMenteeApplication::NotesComponent.new(mentee_application: @user_mentee_application) %>
+      <%= turbo_frame_tag "#{dom_id(@user_mentee_application)}--note" do %>
+        <%= render UserMenteeApplication::NotesComponent.new(mentee_application: @user_mentee_application) %>
+      <% end %>
     </span>
 
     <span class="pb-4 inline mx-auto">

--- a/app/views/admin/user_mentee_applications/show.html.erb
+++ b/app/views/admin/user_mentee_applications/show.html.erb
@@ -11,12 +11,9 @@
         </span>
     </div>
 
-      <span class="p-4 inline mx-auto">
-        <span class="font-bold">Reviewer Note:</span>
-        <%= turbo_frame_tag "#{dom_id(@user_mentee_application)}--note" do %>
-          <%= @user_mentee_application.current_state.note %>
-        <% end %>
-      </span>
+    <span class="p-4 inline mx-auto">
+      <%= render UserMenteeApplication::NotesComponent.new(mentee_application: @user_mentee_application) %>
+    </span>
 
     <span class="pb-4 inline mx-auto">
   

--- a/app/views/admin/user_mentee_applications/show.html.erb
+++ b/app/views/admin/user_mentee_applications/show.html.erb
@@ -11,7 +11,8 @@
         </span>
     </div>
 
-    <span class="p-4 inline mx-auto">
+    <hr>
+    <span class="p-4 inline mx-auto text-center">
       <%= render UserMenteeApplication::NotesComponent.new(mentee_application: @user_mentee_application) %>
     </span>
 

--- a/spec/components/user_mentee_application/notes_component_spec.rb
+++ b/spec/components/user_mentee_application/notes_component_spec.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe UserMenteeApplication::NotesComponent, type: :component do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:cohort_name) { 'Test Cohort' }
+  let(:user_mentee_application_cohort) { build(:user_mentee_application_cohort, name: cohort_name) }
+  let(:mentee_application) { create(:user_mentee_application, user_mentee_application_cohort:) }
 
-  # it "renders something useful" do
-  #   expect(
-  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
-  #   ).to include(
-  #     "Hello, components!"
-  #   )
-  # end
+  it 'renders with the latest status selected' do
+    mentee_application.current_state.update(status: 4)
+    render_inline(described_class.new(mentee_application:))
+
+    expect(page).to have_select('status', selected: 'Phone screen scheduled')
+  end
 end

--- a/spec/components/user_mentee_application/notes_component_spec.rb
+++ b/spec/components/user_mentee_application/notes_component_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserMenteeApplication::NotesComponent, type: :component do
+  pending "add some examples to (or delete) #{__FILE__}"
+
+  # it "renders something useful" do
+  #   expect(
+  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
+  #   ).to include(
+  #     "Hello, components!"
+  #   )
+  # end
+end


### PR DESCRIPTION
## What's the change?
On the admin side of User Mentee Application, all reviewer notes are shown in one place using a `select` tag.
The associated Stimulus controller displays a note based on the status selected.

## What key workflows are impacted?
Updating an applicant's status.

## Highlights / Surprises / Risks / Cleanup
When updating an applicant status from the `admin_user_mentee_application_path(:id)`, the `select` element is not automatically updated. Therefore a manual refresh of the page is required to display the new status and note.
I thought about adding a Turbo action to update this `select` tag but since I am using ViewComponents I don't think that is possible. 

## Demo / Screenshots
https://github.com/agency-of-learning/PairApp/assets/85654561/d364e5f9-a64d-4811-b49f-8a59e370847c

## Issue ticket number and link
Closes #429 

## Checklist before requesting a review
- [x] Did you add appropriate automated tests?
- [x] Is everything elevated to the highest level? (e.g., can logic be moved out of view into controllers, or out of controllers into models?)
- [x] Did you add any relevant tags and decide if this PR is a Draft vs. Ready for Review?
