### PR TITLE
Unschedule job for creating standup meetings

### DIFF
--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -13,10 +13,11 @@ s.every '30m' do
   PairRequests::AutoExpireWorker.perform_async
 end
 
+# NOTE: job unscheduled until storage issues are resolved
 # This does a longer look ahead to account for failures and ensure nothing is missed.
-s.every '15m' do
-  StandupMeetingGroups::DetermineMissingStandupMeetingsWorker.perform_async(0, 60)
-end
+# s.every '15m' do
+#   StandupMeetingGroups::DetermineMissingStandupMeetingsWorker.perform_async(0, 60)
+# end
 
 s.every '24h' do
   StandupMeetings::AutoMissedMeetingWorker.perform_async


### PR DESCRIPTION
## What's the change?
Temporarily unschedule job for creating new standup meetings. This is done to conserve storage on heroku's mini postgres db instance.

This will prevent records being created for daily standup meetings. This will also stop creating notification records associated with each meeting.

## Highlights / Surprises / Risks / Cleanup
Potential surprise: I left the other jobs scheduled. This is because those jobs only write to existing records rather than create new ones, so they shouldn't have any impact on storage limits.
